### PR TITLE
feat: Signal Badge System (Buy/Sell Indicators) - closes #29

### DIFF
--- a/components/SignalBadge.tsx
+++ b/components/SignalBadge.tsx
@@ -1,0 +1,21 @@
+type SignalType = "BUY" | "SELL";
+
+interface SignalBadgeProps {
+  signal: SignalType;
+}
+
+export function SignalBadge({ signal }: SignalBadgeProps) {
+  const isBuy = signal === "BUY";
+  return (
+    <span
+      aria-label={isBuy ? "Buy signal" : "Sell signal"}
+      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold tracking-wide ${
+        isBuy
+          ? "bg-green-500 text-white"
+          : "bg-red-500 text-white"
+      }`}
+    >
+      {signal}
+    </span>
+  );
+}

--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -1,0 +1,21 @@
+import { SignalBadge } from "./SignalBadge";
+
+interface SignalCardProps {
+  asset: string;
+  signal: "BUY" | "SELL";
+  description?: string;
+}
+
+export function SignalCard({ asset, signal, description }: SignalCardProps) {
+  return (
+    <div className="rounded-2xl border bg-card p-5 shadow-sm flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold text-lg">{asset}</span>
+        <SignalBadge signal={signal} />
+      </div>
+      {description && (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Resolves #29

## Changes

- **`SignalBadge`** — pill-shaped badge component that renders a `BUY` (green) or `SELL` (red) indicator with an `aria-label` for screen reader accessibility.
- **`SignalCard`** — card component that displays an asset name alongside the `SignalBadge`.

## Acceptance Criteria

- [x] Renders BUY or SELL badge on the card
- [x] Pill-shaped badge styling with high contrast
- [x] Badge color updates dynamically based on signal type (green = BUY, red = SELL)
- [x] Accessible text via `aria-label` for screen readers