### PR TITLE
feat: Timestamp Display and Auto-Refresh - closes #30

### DIFF
--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { SignalTimestamp } from "./SignalTimestamp";
+
+interface SignalCardProps {
+  asset: string;
+  signal: "BUY" | "SELL";
+  updatedAt: Date;
+  description?: string;
+}
+
+export function SignalCard({ asset, signal, updatedAt, description }: SignalCardProps) {
+  const isBuy = signal === "BUY";
+  return (
+    <div className="rounded-2xl border bg-card p-5 shadow-sm flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold text-lg">{asset}</span>
+        <span
+          aria-label={isBuy ? "Buy signal" : "Sell signal"}
+          className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold tracking-wide ${
+            isBuy ? "bg-green-500 text-white" : "bg-red-500 text-white"
+          }`}
+        >
+          {signal}
+        </span>
+      </div>
+      {description && (
+        <p className="text-sm text-muted-foreground">{description}</p>
+      )}
+      <SignalTimestamp updatedAt={updatedAt} />
+    </div>
+  );
+}

--- a/components/SignalTimestamp.tsx
+++ b/components/SignalTimestamp.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useRelativeTime } from "@/hooks/useRelativeTime";
+
+interface SignalTimestampProps {
+  updatedAt: Date;
+}
+
+export function SignalTimestamp({ updatedAt }: SignalTimestampProps) {
+  const label = useRelativeTime(updatedAt);
+  return (
+    <span className="text-xs text-muted-foreground">Updated {label}</span>
+  );
+}

--- a/hooks/useRelativeTime.ts
+++ b/hooks/useRelativeTime.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+function getRelativeTime(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function useRelativeTime(date: Date): string {
+  const [label, setLabel] = useState(() => getRelativeTime(date));
+
+  useEffect(() => {
+    setLabel(getRelativeTime(date));
+    const id = setInterval(() => setLabel(getRelativeTime(date)), 60_000);
+    return () => clearInterval(id);
+  }, [date]);
+
+  return label;
+}


### PR DESCRIPTION
## Summary

Resolves #30

## Changes

- **`hooks/useRelativeTime.ts`** — hook that computes a relative time string (`just now`, `Xm ago`, `Xh ago`, `Xd ago`) and re-evaluates every 60 seconds via `setInterval`, cleaning up on unmount to avoid unnecessary re-renders.
- **`components/SignalTimestamp.tsx`** — renders `Updated {label}` using the hook.
- **`components/SignalCard.tsx`** — integrates `SignalTimestamp` alongside the BUY/SELL badge.

## Acceptance Criteria

- [x] Shows relative time e.g. `Updated 2m ago`
- [x] Auto-updates every minute
- [x] Handles `just now`, minutes, hours, and days
- [x] Syncs with real-time data via `updatedAt` prop
- [x] Avoids unnecessary re-renders (interval only, no polling)