### PR TITLE
feat: add stop-loss slider (#22) and copy-to-clipboard utility (#37)

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { StopLossSlider } from "@/components/ui/stop-loss-slider";
+import { CopyField } from "@/components/ui/copy-field";
+import { CopyButton } from "@/components/ui/copy-button";
+import { useStopLoss } from "@/hooks/useStopLoss";
+
+const MOCK_WALLET = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const MOCK_TX_HASH =
+  "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+const ENTRY_PRICE = 0.1234; // XLM price in USD
+
+export default function DemoPage() {
+  const { stopLossPercent, stopLossPrice, setStopLossPercent, reset } =
+    useStopLoss({ initialValue: 5, entryPrice: ENTRY_PRICE });
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-10 p-8">
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="w-full max-w-md space-y-10"
+      >
+        <h1 className="text-2xl font-bold tracking-tight">Component Demo</h1>
+
+        {/* ── Issue #22: Stop-Loss Slider ─────────────────────────────── */}
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
+          <h2 className="text-base font-semibold">
+            #22 — Stop-Loss Slider
+          </h2>
+
+          <StopLossSlider
+            value={stopLossPercent}
+            onChange={setStopLossPercent}
+            entryPrice={ENTRY_PRICE}
+            assetSymbol="XLM"
+          />
+
+          <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <span>
+              Stop price:{" "}
+              <strong className="text-foreground">
+                {stopLossPrice?.toFixed(6) ?? "—"} XLM
+              </strong>
+            </span>
+            <button
+              onClick={reset}
+              className="text-xs underline underline-offset-2 hover:text-foreground transition-colors"
+            >
+              Reset
+            </button>
+          </div>
+
+          {/* Simulate modal persistence */}
+          <button
+            onClick={() => setModalOpen((o) => !o)}
+            className="w-full rounded-md border border-input bg-background px-4 py-2 text-sm hover:bg-accent transition-colors"
+          >
+            {modalOpen ? "Close modal (value persists)" : "Open modal"}
+          </button>
+
+          {modalOpen && (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.97 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="rounded-lg border border-border bg-muted/40 p-4 space-y-3"
+            >
+              <p className="text-xs text-muted-foreground">
+                Modal is open — slider value persists:
+              </p>
+              <StopLossSlider
+                value={stopLossPercent}
+                onChange={setStopLossPercent}
+                entryPrice={ENTRY_PRICE}
+                assetSymbol="XLM"
+              />
+            </motion.div>
+          )}
+        </section>
+
+        {/* ── Issue #37: Copy-to-Clipboard ────────────────────────────── */}
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm space-y-4">
+          <h2 className="text-base font-semibold">
+            #37 — Copy-to-Clipboard
+          </h2>
+
+          <CopyField
+            label="Wallet Address"
+            value={MOCK_WALLET}
+            truncateChars={8}
+          />
+
+          <CopyField
+            label="Transaction Hash"
+            value={MOCK_TX_HASH}
+            truncateChars={10}
+          />
+
+          {/* Standalone CopyButton usage */}
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">
+              Inline copy button:
+            </span>
+            <CopyButton value={MOCK_WALLET} label="Copy address" />
+          </div>
+        </section>
+      </motion.div>
+    </main>
+  );
+}

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useClipboard } from "@/hooks/useClipboard";
+
+export interface CopyButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** The text value to copy to the clipboard */
+  value: string;
+  /** Label shown in the tooltip / aria-label before copying */
+  label?: string;
+  /** How long (ms) the "Copied!" state persists. Default: 2000 */
+  resetDelay?: number;
+}
+
+/**
+ * CopyButton — copies `value` to the clipboard on click and shows a brief
+ * "Copied!" confirmation that disappears automatically.
+ *
+ * Works across browsers via the Clipboard API with a legacy execCommand
+ * fallback (see useClipboard hook).
+ */
+const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
+  (
+    { value, label = "Copy", resetDelay = 2000, className, ...props },
+    ref
+  ) => {
+    const { copied, copy } = useClipboard({ resetDelay });
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        aria-label={copied ? "Copied!" : label}
+        title={copied ? "Copied!" : label}
+        onClick={() => copy(value)}
+        className={cn(
+          // Base styles
+          "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium",
+          "transition-all duration-200 select-none",
+          // Default appearance
+          "border border-input bg-background text-muted-foreground",
+          "hover:bg-accent hover:text-accent-foreground",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          "disabled:pointer-events-none disabled:opacity-50",
+          // Copied state
+          copied && "border-green-500/40 bg-green-500/10 text-green-600 dark:text-green-400",
+          className
+        )}
+        {...props}
+      >
+        <span
+          className={cn(
+            "transition-transform duration-200",
+            copied ? "scale-110" : "scale-100"
+          )}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+        </span>
+        <span>{copied ? "Copied!" : label}</span>
+      </button>
+    );
+  }
+);
+CopyButton.displayName = "CopyButton";
+
+export { CopyButton };

--- a/components/ui/copy-field.tsx
+++ b/components/ui/copy-field.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { CopyButton } from "./copy-button";
+
+export interface CopyFieldProps {
+  /** The full value (wallet address, tx hash, etc.) */
+  value: string;
+  /** Optional label shown above the field */
+  label?: string;
+  /** Truncate the displayed value. Default: true */
+  truncate?: boolean;
+  /** Number of chars to show at start/end when truncated. Default: 8 */
+  truncateChars?: number;
+  className?: string;
+}
+
+/**
+ * CopyField — displays a truncated address/hash with an inline CopyButton.
+ * Suitable for wallet addresses and transaction hashes.
+ */
+export function CopyField({
+  value,
+  label,
+  truncate = true,
+  truncateChars = 8,
+  className,
+}: CopyFieldProps) {
+  const display =
+    truncate && value.length > truncateChars * 2 + 3
+      ? `${value.slice(0, truncateChars)}...${value.slice(-truncateChars)}`
+      : value;
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      {label && (
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      )}
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-md border border-input bg-muted/40 px-3 py-2"
+        )}
+      >
+        <span
+          className="flex-1 truncate font-mono text-sm text-foreground"
+          title={value}
+          aria-label={value}
+        >
+          {display}
+        </span>
+        <CopyButton value={value} label={`Copy ${label ?? "value"}`} />
+      </div>
+    </div>
+  );
+}

--- a/components/ui/stop-loss-slider.tsx
+++ b/components/ui/stop-loss-slider.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface StopLossSliderProps {
+  /** Current stop-loss percentage (0–100) */
+  value: number;
+  /** Called in real time as the slider moves */
+  onChange: (value: number) => void;
+  /** Optional entry price used to compute the stop-loss price */
+  entryPrice?: number;
+  /** Optional asset symbol, e.g. "XLM" */
+  assetSymbol?: string;
+  /** Minimum percentage. Default: 0 */
+  min?: number;
+  /** Maximum percentage. Default: 100 */
+  max?: number;
+  /** Step increment. Default: 1 */
+  step?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * StopLossSlider — accessible range input for selecting a stop-loss percentage.
+ *
+ * Features:
+ * - Real-time updates while dragging
+ * - Keyboard navigation (arrow keys, Home, End)
+ * - Active track highlight proportional to the selected value
+ * - Displays the corresponding price when entryPrice is provided
+ * - ARIA attributes for screen readers
+ * - Value persists while the parent keeps it in state
+ */
+export function StopLossSlider({
+  value,
+  onChange,
+  entryPrice,
+  assetSymbol = "XLM",
+  min = 0,
+  max = 100,
+  step = 1,
+  disabled = false,
+  className,
+}: StopLossSliderProps) {
+  const id = React.useId();
+  const trackRef = React.useRef<HTMLDivElement>(null);
+
+  // Clamp helper
+  const clamp = (v: number) => Math.min(max, Math.max(min, v));
+
+  // Percentage of the track filled
+  const fillPercent = ((clamp(value) - min) / (max - min)) * 100;
+
+  // Derived stop-loss price
+  const stopPrice =
+    entryPrice != null
+      ? (entryPrice * (1 - clamp(value) / 100)).toFixed(4)
+      : null;
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    onChange(clamp(Number(e.target.value)));
+  }
+
+  // Colour the thumb/track based on risk level
+  const riskColor =
+    value <= 10
+      ? "text-green-500"
+      : value <= 30
+      ? "text-yellow-500"
+      : "text-red-500";
+
+  const trackFillColor =
+    value <= 10
+      ? "bg-green-500"
+      : value <= 30
+      ? "bg-yellow-500"
+      : "bg-red-500";
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor={id}
+          className="text-sm font-medium text-foreground"
+        >
+          Stop-Loss
+        </label>
+        <div className="flex items-center gap-2">
+          <span
+            className={cn("text-sm font-semibold tabular-nums", riskColor)}
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {clamp(value)}%
+          </span>
+          {stopPrice && (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              ≈ {stopPrice} {assetSymbol}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Track + thumb */}
+      <div className="relative flex items-center" ref={trackRef}>
+        {/* Background track */}
+        <div className="absolute h-1.5 w-full rounded-full bg-muted" />
+
+        {/* Active (filled) track */}
+        <div
+          className={cn(
+            "absolute h-1.5 rounded-full transition-all duration-75",
+            trackFillColor
+          )}
+          style={{ width: `${fillPercent}%` }}
+          aria-hidden="true"
+        />
+
+        {/* Native range input — sits on top, transparent */}
+        <input
+          id={id}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={clamp(value)}
+          onChange={handleChange}
+          disabled={disabled}
+          aria-label="Stop-loss percentage"
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={clamp(value)}
+          aria-valuetext={`${clamp(value)}% stop-loss${stopPrice ? `, price ${stopPrice} ${assetSymbol}` : ""}`}
+          className={cn(
+            // Reset native styles, keep it accessible
+            "relative w-full cursor-pointer appearance-none bg-transparent",
+            "h-5 focus:outline-none",
+            // Thumb styles via CSS custom properties (Tailwind-compatible)
+            "[&::-webkit-slider-thumb]:appearance-none",
+            "[&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4",
+            "[&::-webkit-slider-thumb]:rounded-full",
+            "[&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background",
+            "[&::-webkit-slider-thumb]:shadow-md",
+            "[&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:duration-100",
+            "[&::-webkit-slider-thumb]:hover:scale-110",
+            value <= 10
+              ? "[&::-webkit-slider-thumb]:bg-green-500"
+              : value <= 30
+              ? "[&::-webkit-slider-thumb]:bg-yellow-500"
+              : "[&::-webkit-slider-thumb]:bg-red-500",
+            // Firefox
+            "[&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4",
+            "[&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2",
+            "[&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:shadow-md",
+            value <= 10
+              ? "[&::-moz-range-thumb]:bg-green-500"
+              : value <= 30
+              ? "[&::-moz-range-thumb]:bg-yellow-500"
+              : "[&::-moz-range-thumb]:bg-red-500",
+            // Focus ring on thumb
+            "focus-visible:[&::-webkit-slider-thumb]:ring-2",
+            "focus-visible:[&::-webkit-slider-thumb]:ring-ring",
+            "focus-visible:[&::-webkit-slider-thumb]:ring-offset-1",
+            disabled && "cursor-not-allowed opacity-50"
+          )}
+        />
+      </div>
+
+      {/* Min / Max labels */}
+      <div className="flex justify-between text-xs text-muted-foreground select-none">
+        <span>{min}%</span>
+        <span>{max}%</span>
+      </div>
+
+      {/* Risk hint */}
+      <p className="text-xs text-muted-foreground" aria-live="polite">
+        {value === 0
+          ? "No stop-loss set."
+          : value <= 10
+          ? "Low risk — tight stop."
+          : value <= 30
+          ? "Moderate risk."
+          : "High risk — wide stop."}
+      </p>
+    </div>
+  );
+}

--- a/hooks/useClipboard.ts
+++ b/hooks/useClipboard.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+interface UseClipboardOptions {
+  /** Duration in ms before the "copied" state resets. Default: 2000 */
+  resetDelay?: number;
+}
+
+interface UseClipboardReturn {
+  copied: boolean;
+  copy: (text: string) => Promise<void>;
+}
+
+/**
+ * Utility hook for copying text to the clipboard with visual feedback state.
+ * Falls back to the legacy execCommand approach for browsers that don't
+ * support the Clipboard API (e.g. older Safari, non-secure contexts).
+ */
+export function useClipboard(
+  options: UseClipboardOptions = {}
+): UseClipboardReturn {
+  const { resetDelay = 2000 } = options;
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        if (navigator?.clipboard?.writeText) {
+          await navigator.clipboard.writeText(text);
+        } else {
+          // Legacy fallback
+          const textarea = document.createElement("textarea");
+          textarea.value = text;
+          textarea.style.position = "fixed";
+          textarea.style.opacity = "0";
+          document.body.appendChild(textarea);
+          textarea.focus();
+          textarea.select();
+          document.execCommand("copy");
+          document.body.removeChild(textarea);
+        }
+        setCopied(true);
+        setTimeout(() => setCopied(false), resetDelay);
+      } catch (err) {
+        console.error("Failed to copy to clipboard:", err);
+      }
+    },
+    [resetDelay]
+  );
+
+  return { copied, copy };
+}

--- a/hooks/useStopLoss.ts
+++ b/hooks/useStopLoss.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+interface UseStopLossOptions {
+  /** Initial stop-loss percentage. Default: 5 */
+  initialValue?: number;
+  /** Entry price of the asset being traded */
+  entryPrice?: number;
+}
+
+interface UseStopLossReturn {
+  /** Current stop-loss percentage (0–100) */
+  stopLossPercent: number;
+  /** Derived stop-loss price, or null if no entryPrice provided */
+  stopLossPrice: number | null;
+  /** Update the stop-loss percentage */
+  setStopLossPercent: (value: number) => void;
+  /** Reset to the initial value */
+  reset: () => void;
+}
+
+/**
+ * useStopLoss — manages stop-loss percentage state and derives the
+ * corresponding price from an optional entry price.
+ *
+ * The value persists in component state for the lifetime of the parent
+ * (e.g. while a trade-setup modal is open).
+ */
+export function useStopLoss(
+  options: UseStopLossOptions = {}
+): UseStopLossReturn {
+  const { initialValue = 5, entryPrice } = options;
+
+  const [stopLossPercent, setStopLossPercent] = useState<number>(initialValue);
+
+  const stopLossPrice =
+    entryPrice != null
+      ? entryPrice * (1 - stopLossPercent / 100)
+      : null;
+
+  const reset = useCallback(() => {
+    setStopLossPercent(initialValue);
+  }, [initialValue]);
+
+  return {
+    stopLossPercent,
+    stopLossPrice,
+    setStopLossPercent,
+    reset,
+  };
+}


### PR DESCRIPTION
Closes #22 
Closes #37
Issue #22 - Stop-Loss Slider Component with Dynamic Feedback:
- Add StopLossSlider component with real-time percentage and price updates
- Active track highlight with risk-level colour coding (green/yellow/red)
- Full ARIA attributes for screen reader accessibility
- Keyboard navigation via native range input (arrow keys, Home, End)
- Add useStopLoss hook to manage state and derive stop-loss price
- Value persists in parent state while modal remains open

Issue #37 - Copy-to-Clipboard Utility with Visual Feedback:
- Add useClipboard hook using Clipboard API with execCommand fallback
- Add CopyButton component with animated Copied! confirmation state
- Add CopyField component for wallet addresses and transaction hashes
- Visual feedback auto-resets after 2s (configurable)
- Works across browsers including legacy fallback

Add app/demo/page.tsx to demonstrate both components