### PR TITLE
feature:Pass Signal Interaction Feedback

### DIFF
--- a/store/useSignalStore.ts
+++ b/store/useSignalStore.ts
@@ -1,0 +1,40 @@
+import { create } from "zustand";
+
+export interface Signal {
+  id: string;
+  asset: string;
+  signal: "BUY" | "SELL";
+  description?: string;
+  price: number;
+}
+
+interface SignalState {
+  queue: Signal[];
+  isPassing: boolean;
+  passSignal: () => void;
+  setQueue: (signals: Signal[]) => void;
+  setIsPassing: (value: boolean) => void;
+}
+
+export const useSignalStore = create<SignalState>()((set, get) => ({
+  queue: [],
+  isPassing: false,
+
+  setQueue: (signals) => set({ queue: signals }),
+
+  setIsPassing: (value) => set({ isPassing: value }),
+
+  passSignal: () => {
+    const { isPassing, queue } = get();
+    // Debounce guard — prevent multiple rapid clicks
+    if (isPassing || queue.length === 0) return;
+    set({ isPassing: true });
+    // Remove the first card after the exit animation completes (~400ms)
+    setTimeout(() => {
+      set((state) => ({
+        queue: state.queue.slice(1),
+        isPassing: false,
+      }));
+    }, 400);
+  },
+}));


### PR DESCRIPTION
closes #25


Description:
Add clear feedback for the Pass Signal action so users know the card was dismissed.

Acceptance Criteria:

Clicking Pass Signal removes the current card with an exit animation.
Show brief feedback such as fade or toast.
Load the next card automatically.
Prevent multiple rapid clicks.
Maintain smooth transition.
Priority: Medium
Dependencies: signal card interaction logic.