### PR TITLE
feat: add wallet selection modal for Freighter connection flow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,11 +5,13 @@ import { motion } from "framer-motion";
 import { useWallet } from "@/hooks/useWallet";
 import { Button } from "@/components/ui/button";
 import { TradeModal } from "@/components/TradeModal";
+import { WalletSelectionModal } from "@/components/WalletSelectionModal";
 import { SignalCard } from "@/components/SignalCard";
 
 export default function Home() {
-  const { publicKey, connected, connect, disconnect } = useWallet();
+  const { publicKey, connected, disconnect } = useWallet();
   const [modalOpen, setModalOpen] = useState(false);
+  const [walletModalOpen, setWalletModalOpen] = useState(false);
   const [marketPrice, setMarketPrice] = useState(0.4821);
   const [loading, setLoading] = useState(false);
 
@@ -53,7 +55,7 @@ export default function Home() {
             <Button variant="outline" onClick={disconnect}>Disconnect</Button>
           </>
         ) : (
-          <Button onClick={connect} size="lg">Connect Wallet</Button>
+          <Button onClick={() => setWalletModalOpen(true)} size="lg">Connect Wallet</Button>
         )}
       </motion.div>
 
@@ -81,6 +83,11 @@ export default function Home() {
         onClose={() => setModalOpen(false)}
         marketPrice={marketPrice}
         walletBalance={250}
+      />
+
+      <WalletSelectionModal
+        open={walletModalOpen}
+        onClose={() => setWalletModalOpen(false)}
       />
     </main>
   );

--- a/components/WalletSelectionModal.tsx
+++ b/components/WalletSelectionModal.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Wallet, Loader2, ExternalLink } from "lucide-react";
+import { useWallet } from "@/hooks/useWallet";
+
+interface WalletSelectionModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface WalletOption {
+  id: string;
+  name: string;
+  description: string;
+  installUrl: string;
+}
+
+const WALLET_OPTIONS: WalletOption[] = [
+  {
+    id: "freighter",
+    name: "Freighter",
+    description:
+      "The official browser extension wallet for the Stellar network, built by the Stellar Development Foundation.",
+    installUrl: "https://www.freighter.app",
+  },
+];
+
+export function WalletSelectionModal({ open, onClose }: WalletSelectionModalProps) {
+  const { connect, isConnecting } = useWallet();
+  const [selectedWallet, setSelectedWallet] = useState<string | null>(null);
+
+  // ESC to close
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Reset selection when modal closes
+  useEffect(() => {
+    if (!open) setSelectedWallet(null);
+  }, [open]);
+
+  async function handleSelectWallet(walletId: string) {
+    if (isConnecting) return;
+    setSelectedWallet(walletId);
+    await connect();
+    onClose();
+  }
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          {/* Overlay */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <motion.div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Connect Wallet"
+            className="relative z-10 w-full max-w-sm rounded-2xl border border-gray-700/60 bg-gray-900/95 p-6 shadow-2xl"
+            initial={{ scale: 0.92, opacity: 0, y: 20 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.92, opacity: 0, y: 20 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between mb-2">
+              <h2 className="text-lg font-semibold text-white">Connect Wallet</h2>
+              <button
+                onClick={onClose}
+                aria-label="Close wallet selection"
+                className="rounded-full p-1 text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <p className="text-sm text-gray-400 mb-5">
+              Choose a wallet to connect to StellarSwipe
+            </p>
+
+            {/* Wallet options */}
+            <div className="space-y-3">
+              {WALLET_OPTIONS.map((wallet) => {
+                const isSelected = selectedWallet === wallet.id;
+                const loading = isSelected && isConnecting;
+
+                return (
+                  <button
+                    key={wallet.id}
+                    onClick={() => handleSelectWallet(wallet.id)}
+                    disabled={isConnecting}
+                    className="w-full flex items-start gap-4 rounded-xl border border-white/10 bg-white/5 p-4 text-left hover:border-blue-500/50 hover:bg-white/10 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed"
+                  >
+                    {/* Icon */}
+                    <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-600/20 border border-blue-500/30">
+                      {loading ? (
+                        <Loader2 size={20} className="text-blue-400 animate-spin" />
+                      ) : (
+                        <Wallet size={20} className="text-blue-400" />
+                      )}
+                    </div>
+
+                    {/* Text */}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-white">{wallet.name}</p>
+                      <p className="mt-0.5 text-xs text-gray-400 leading-relaxed">
+                        {wallet.description}
+                      </p>
+                      {loading && (
+                        <p className="mt-1.5 text-xs text-blue-400">Connecting…</p>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Footer */}
+            <p className="mt-5 text-center text-xs text-gray-500">
+              Don&apos;t have a wallet?{" "}
+              <a
+                href="https://www.freighter.app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 hover:text-blue-300 inline-flex items-center gap-1 underline-offset-2 hover:underline"
+              >
+                Install Freighter <ExternalLink size={11} />
+              </a>
+            </p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   isConnected,
   getAddress,
@@ -11,9 +12,11 @@ import { toast } from "@/lib/toast";
 export function useWallet() {
   const { publicKey, isConnected: connected, setPublicKey, setConnected, disconnect } =
     useWalletStore();
+  const [isConnecting, setIsConnecting] = useState(false);
 
   async function connect() {
     try {
+      setIsConnecting(true);
       const connectedResponse = await isConnected();
       if (!connectedResponse?.isConnected) {
         toast.error("Freighter wallet not found. Please install it.");
@@ -28,6 +31,8 @@ export function useWallet() {
     } catch (err) {
       toast.error("Failed to connect wallet");
       console.error(err);
+    } finally {
+      setIsConnecting(false);
     }
   }
 
@@ -36,5 +41,5 @@ export function useWallet() {
     toast.info("Wallet disconnected");
   }
 
-  return { publicKey, connected, connect, disconnect: disconnectWallet };
+  return { publicKey, connected, connect, disconnect: disconnectWallet, isConnecting };
 }


### PR DESCRIPTION
Closes #2

---

## Summary

- Adds a new `WalletSelectionModal` component that opens when the user clicks **Connect Wallet**, replacing the previous direct `connect()` call.
- Lists Freighter as the supported wallet with name and descriptive copy, matching the Stellar Development Foundation branding.
- Shows a spinner + "Connecting…" label on the selected wallet card while the connection flow is in progress.
- Adds `isConnecting` loading state to `useWallet` hook (with proper `finally` cleanup).

## What changed

| File | Change |
|------|--------|
| `components/WalletSelectionModal.tsx` | New modal component |
| `hooks/useWallet.ts` | Added `isConnecting` state, `finally` block |
| `app/page.tsx` | Connect Wallet button opens modal; `WalletSelectionModal` mounted at page root |

## Accessibility & UX

- `role="dialog"` + `aria-modal="true"` + `aria-label="Connect Wallet"` on the dialog panel
- Accessible close button with `aria-label="Close wallet selection"`
- ESC key dismisses the dialog
- `focus-visible` ring on the wallet option button for keyboard navigation
- Backdrop click also closes the modal
- "Don't have a wallet? Install Freighter" footer link for new users

## Reviewer notes

- Follows the same Framer Motion `AnimatePresence` + spring animation pattern used by `TradeModal.tsx` — no new animation dependencies.
- The `WALLET_OPTIONS` array in the modal is structured to make adding future wallets (e.g. Albedo, xBull) straightforward.
- `isConnecting` lives in the hook as local state (not the Zustand store) since it's transient UI state that doesn't need persistence.

## Test plan

- [ ] Click **Connect Wallet** → modal opens with Freighter listed
- [ ] Click Freighter card → spinner appears and "Connecting…" label shown; Freighter extension prompt fires
- [ ] Successful connection → modal closes, public key shown in header
- [ ] ESC key closes modal without connecting
- [ ] Click backdrop closes modal
- [ ] Close button (×) closes modal
- [ ] Tab key navigates to wallet card and close button; Enter/Space activates them