### PR TITLE
feat: standardize dark theme with semantic CSS tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,49 +1,105 @@
 @import "tailwindcss";
 
 @layer base {
+  /*
+   * StellarSwipe design tokens — dark-first theme.
+   * All values are HSL channels (no `hsl()` wrapper) so Tailwind can apply
+   * opacity modifiers: e.g. `bg-background/80`.
+   *
+   * Semantic layers
+   * ───────────────
+   * background   — page canvas          (darkest)
+   * surface      — card / panel         (one step lighter)
+   * surface-high — elevated card        (two steps lighter)
+   * overlay      — modal backdrop fill
+   *
+   * Text
+   * ────
+   * foreground        — primary body text
+   * foreground-muted  — secondary / caption text
+   * foreground-subtle — placeholder / disabled text
+   *
+   * Borders & inputs
+   * ────────────────
+   * border       — default divider
+   * border-strong — hover / focus divider
+   * input        — input background
+   * ring         — focus ring
+   *
+   * Semantic accents (used for status, badges, CTAs)
+   * ─────────────────────────────────────────────────
+   * accent-primary   — blue CTA
+   * accent-sky       — sky highlight (signal feed labels)
+   * accent-success   — green / emerald (buy, success)
+   * accent-danger    — red (sell, error, stop-loss high)
+   * accent-warning   — orange / amber (stop-loss mid, price impact)
+   * accent-market    — indigo (market-order variant)
+   */
+
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
+    /* ── Light fallback (not used — app is dark-only) ── */
+    --background:     222 47% 8%;
+    --surface:        222 40% 11%;
+    --surface-high:   222 35% 15%;
+    --overlay:        0 0% 0%;
+
+    --foreground:        210 40% 96%;
+    --foreground-muted:  215 20% 60%;
+    --foreground-subtle: 215 15% 40%;
+
+    --border:        217 30% 18%;
+    --border-strong: 217 30% 28%;
+    --input:         222 40% 11%;
+    --ring:          217 91% 60%;
+
+    --accent-primary:  217 91% 60%;
+    --accent-sky:      199 89% 60%;
+    --accent-success:  160 84% 39%;
+    --accent-danger:   0  72% 51%;
+    --accent-warning:  25 95% 53%;
+    --accent-market:   239 84% 67%;
+
+    --radius: 0.75rem;
+
+    /* shadcn/ui compat aliases */
+    --card:                var(--surface);
+    --card-foreground:     var(--foreground);
+    --popover:             var(--surface);
+    --popover-foreground:  var(--foreground);
+    --primary:             var(--accent-primary);
+    --primary-foreground:  210 40% 98%;
+    --secondary:           var(--surface-high);
+    --secondary-foreground:var(--foreground);
+    --muted:               var(--surface-high);
+    --muted-foreground:    var(--foreground-muted);
+    --accent:              var(--surface-high);
+    --accent-foreground:   var(--foreground);
+    --destructive:         var(--accent-danger);
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.5rem;
   }
 
+  /* Dark class kept for shadcn/ui compatibility — tokens are identical */
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    --background:     222 47% 8%;
+    --surface:        222 40% 11%;
+    --surface-high:   222 35% 15%;
+    --overlay:        0 0% 0%;
+
+    --foreground:        210 40% 96%;
+    --foreground-muted:  215 20% 60%;
+    --foreground-subtle: 215 15% 40%;
+
+    --border:        217 30% 18%;
+    --border-strong: 217 30% 28%;
+    --input:         222 40% 11%;
+    --ring:          217 91% 60%;
+
+    --accent-primary:  217 91% 60%;
+    --accent-sky:      199 89% 60%;
+    --accent-success:  160 84% 39%;
+    --accent-danger:   0  72% 51%;
+    --accent-warning:  25 95% 53%;
+    --accent-market:   239 84% 67%;
   }
 }
 
@@ -51,8 +107,48 @@
   * {
     border-color: hsl(var(--border));
   }
+
+  html {
+    color-scheme: dark;
+  }
+
   body {
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+    font-family: var(--font-sans), system-ui, sans-serif;
   }
+}
+
+/* ── Utility classes for tokens not covered by Tailwind's default palette ── */
+@layer utilities {
+  .bg-surface        { background-color: hsl(var(--surface)); }
+  .bg-surface-high   { background-color: hsl(var(--surface-high)); }
+  .bg-overlay        { background-color: hsl(var(--overlay)); }
+
+  .text-foreground-muted  { color: hsl(var(--foreground-muted)); }
+  .text-foreground-subtle { color: hsl(var(--foreground-subtle)); }
+
+  .border-strong { border-color: hsl(var(--border-strong)); }
+
+  .text-accent-sky     { color: hsl(var(--accent-sky)); }
+  .text-accent-success { color: hsl(var(--accent-success)); }
+  .text-accent-danger  { color: hsl(var(--accent-danger)); }
+  .text-accent-warning { color: hsl(var(--accent-warning)); }
+  .text-accent-market  { color: hsl(var(--accent-market)); }
+
+  .bg-accent-primary\/10  { background-color: hsl(var(--accent-primary) / 0.10); }
+  .bg-accent-success\/10  { background-color: hsl(var(--accent-success) / 0.10); }
+  .bg-accent-success\/20  { background-color: hsl(var(--accent-success) / 0.20); }
+  .bg-accent-danger\/10   { background-color: hsl(var(--accent-danger)  / 0.10); }
+  .bg-accent-danger\/20   { background-color: hsl(var(--accent-danger)  / 0.20); }
+  .bg-accent-market\/10   { background-color: hsl(var(--accent-market)  / 0.10); }
+  .bg-accent-market\/40   { background-color: hsl(var(--accent-market)  / 0.40); }
+
+  .border-accent-success\/20 { border-color: hsl(var(--accent-success) / 0.20); }
+  .border-accent-danger\/20  { border-color: hsl(var(--accent-danger)  / 0.20); }
+  .border-accent-market\/30  { border-color: hsl(var(--accent-market)  / 0.30); }
+  .border-accent-danger\/10  { border-color: hsl(var(--accent-danger)  / 0.10); }
+
+  .ring-accent-sky    { --tw-ring-color: hsl(var(--accent-sky)); }
+  .ring-accent-warning { --tw-ring-color: hsl(var(--accent-warning)); }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
         <Providers>{children}</Providers>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8 bg-gray-950">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8 bg-background">
       <motion.div
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -33,7 +33,7 @@ export default function Home() {
         className="relative text-center"
       >
         <h1 className="text-4xl font-bold tracking-tight text-white">StellarSwipe</h1>
-        <p className="mt-2 text-gray-400">
+        <p className="mt-2 text-foreground-muted">
           Connect your Freighter wallet to get started
         </p>
       </motion.div>
@@ -47,7 +47,7 @@ export default function Home() {
       >
         {connected ? (
           <>
-            <p className="text-sm text-gray-400 font-mono">
+            <p className="text-sm text-foreground-muted font-mono">
               {publicKey?.slice(0, 8)}...{publicKey?.slice(-8)}
             </p>
             <Button variant="outline" onClick={disconnect}>Disconnect</Button>
@@ -63,13 +63,13 @@ export default function Home() {
         <div className="flex gap-3">
           <button
             onClick={toggleLoading}
-            className="text-xs text-gray-500 hover:text-gray-300 underline transition-colors"
+            className="text-xs text-foreground-subtle hover:text-foreground-muted underline transition-colors"
           >
             Preview skeleton
           </button>
           <button
             onClick={() => setModalOpen(true)}
-            className="text-xs text-gray-500 hover:text-gray-300 underline transition-colors"
+            className="text-xs text-foreground-subtle hover:text-foreground-muted underline transition-colors"
           >
             Open trade modal
           </button>

--- a/components/PositionLimitToggle.tsx
+++ b/components/PositionLimitToggle.tsx
@@ -31,15 +31,15 @@ export function PositionLimitToggle({
   };
 
   return (
-    <div className="w-full rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 transition-colors hover:border-zinc-700/50">
+    <div className="w-full rounded-xl border border-border bg-surface/60 p-4 transition-colors hover:border-border-strong">
       {/* Header row */}
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <Shield className="h-4 w-4 text-zinc-400" />
-          <span className="text-sm font-medium text-zinc-200">Position Limit</span>
+          <Shield className="h-4 w-4 text-foreground-muted" />
+          <span className="text-sm font-medium text-foreground">Position Limit</span>
           <div className="group relative">
-            <Info className="h-3.5 w-3.5 text-zinc-600 cursor-help" />
-            <div className="absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-xs text-zinc-400 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 pointer-events-none">
+            <Info className="h-3.5 w-3.5 text-foreground-subtle cursor-help" />
+            <div className="absolute bottom-full left-1/2 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-border bg-surface px-3 py-2 text-xs text-foreground-muted opacity-0 shadow-lg transition-opacity group-hover:opacity-100 pointer-events-none">
               Cap your trade to a percentage of your portfolio
             </div>
           </div>
@@ -52,12 +52,12 @@ export function PositionLimitToggle({
           aria-label="Toggle position limit"
           disabled={!portfolioAvailable}
           onClick={toggle}
-          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 ${
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
             !portfolioAvailable
               ? "cursor-not-allowed opacity-40"
               : enabled
-                ? "bg-blue-600"
-                : "bg-zinc-700"
+                ? "bg-primary"
+                : "bg-foreground/20"
           }`}
         >
           <motion.span
@@ -81,18 +81,18 @@ export function PositionLimitToggle({
         className="overflow-hidden"
       >
         <div className="mt-3 space-y-3">
-          <p className="text-xs text-zinc-500">
-            Cap trade at <span className="font-medium text-zinc-300">{percentage}%</span> of portfolio
+          <p className="text-xs text-foreground-subtle">
+            Cap trade at <span className="font-medium text-foreground">{percentage}%</span> of portfolio
             {calculatedLimit && (
-              <span className="text-zinc-400">
-                {" "}· Max trade: <span className="font-mono text-zinc-200">{calculatedLimit} XLM</span>
+              <span className="text-foreground-muted">
+                {" "}· Max trade: <span className="font-mono text-foreground">{calculatedLimit} XLM</span>
               </span>
             )}
           </p>
 
           {/* Slider */}
           <div className="flex items-center gap-3">
-            <SlidersHorizontal className="h-3.5 w-3.5 text-zinc-500 shrink-0" />
+            <SlidersHorizontal className="h-3.5 w-3.5 text-foreground-subtle shrink-0" />
             <input
               type="range"
               min={1}
@@ -101,15 +101,15 @@ export function PositionLimitToggle({
               value={percentage}
               onChange={handlePercentageChange}
               aria-label="Position limit percentage"
-              className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-zinc-800 accent-blue-500
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-surface-high accent-[hsl(var(--accent-primary))]
                 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4
-                [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-500
-                [&::-webkit-slider-thumb]:shadow-lg [&::-webkit-slider-thumb]:shadow-blue-500/30
+                [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[hsl(var(--accent-primary))]
+                [&::-webkit-slider-thumb]:shadow-lg
                 [&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:hover:scale-110
                 [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full
-                [&::-moz-range-thumb]:bg-blue-500 [&::-moz-range-thumb]:border-0"
+                [&::-moz-range-thumb]:bg-[hsl(var(--accent-primary))] [&::-moz-range-thumb]:border-0"
             />
-            <span className="min-w-[3ch] text-right text-xs font-mono text-zinc-400">
+            <span className="min-w-[3ch] text-right text-xs font-mono text-foreground-muted">
               {percentage}%
             </span>
           </div>
@@ -120,10 +120,12 @@ export function PositionLimitToggle({
               <button
                 key={val}
                 onClick={() => setPercentage(val)}
+                aria-label={`Set position limit to ${val}%`}
+                aria-pressed={percentage === val}
                 className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
                   percentage === val
-                    ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30"
-                    : "bg-zinc-800 text-zinc-500 hover:bg-zinc-700 hover:text-zinc-300"
+                    ? "bg-accent-primary/10 text-accent-sky ring-1 ring-[hsl(var(--accent-primary)/0.3)]"
+                    : "bg-surface-high text-foreground-subtle hover:bg-border hover:text-foreground-muted"
                 }`}
               >
                 {val}%
@@ -138,7 +140,7 @@ export function PositionLimitToggle({
         <motion.p
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="mt-2 text-xs text-amber-500/70"
+          className="mt-2 text-xs text-accent-warning/70"
         >
           Connect wallet and load portfolio to enable position limits
         </motion.p>
@@ -149,7 +151,7 @@ export function PositionLimitToggle({
         <motion.p
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="mt-2 text-xs text-zinc-500"
+          className="mt-2 text-xs text-foreground-subtle"
         >
           Loading portfolio data...
         </motion.p>

--- a/components/SignalBadge.tsx
+++ b/components/SignalBadge.tsx
@@ -11,8 +11,8 @@ export function SignalBadge({ signal }: SignalBadgeProps) {
       aria-label={isBuy ? "Buy signal" : "Sell signal"}
       className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold tracking-wide ${
         isBuy
-          ? "bg-green-500 text-white"
-          : "bg-red-500 text-white"
+          ? "bg-accent-success text-foreground"
+          : "bg-accent-danger text-foreground"
       }`}
     >
       {signal}

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -13,7 +13,6 @@ interface TradeModalProps {
   marketPrice?: number;
 }
 
-// Mock transaction builder
 const mockBuildTx = (order: object) =>
   new Promise<void>((res) => setTimeout(() => { console.log("tx built", order); res(); }, 800));
 
@@ -30,7 +29,6 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
   const insufficient = total > walletBalance;
   const disabled = !amount || (type === "LIMIT" && !limitPrice) || insufficient || submitting;
 
-  // ESC to close
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => e.key === "Escape" && onClose();
@@ -59,17 +57,21 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
           exit={{ opacity: 0 }}
         >
           {/* Overlay */}
-          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+          <div
+            className="absolute inset-0 bg-overlay/60 backdrop-blur-sm"
+            onClick={onClose}
+            aria-hidden="true"
+          />
 
-          {/* Modal */}
+          {/* Modal panel */}
           <motion.div
             role="dialog"
             aria-modal="true"
             aria-label={`${type === "LIMIT" ? "Limit" : "Market"} Order`}
             className={`relative z-10 w-full max-w-md rounded-2xl border p-6 shadow-2xl
               ${type === "MARKET"
-                ? "bg-indigo-950/95 border-indigo-500/40"
-                : "bg-gray-900/95 border-gray-700/60"}`}
+                ? "bg-accent-market/10 border-accent-market/30"
+                : "bg-surface border-border"}`}
             initial={{ scale: 0.92, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             exit={{ scale: 0.92, opacity: 0, y: 20 }}
@@ -77,26 +79,27 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
           >
             {/* Header */}
             <div className="flex items-center justify-between mb-5">
-              <h2 className="text-lg font-semibold text-white">Place Order</h2>
+              <h2 className="text-lg font-semibold text-foreground">Place Order</h2>
               <button
                 onClick={onClose}
                 aria-label="Close modal"
-                className="rounded-full p-1 text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+                className="rounded-full p-1 text-foreground-muted hover:text-foreground hover:bg-foreground/10 transition-colors"
               >
-                <X size={18} />
+                <X size={18} aria-hidden="true" />
               </button>
             </div>
 
-            {/* Market / Limit Toggle */}
-            <div className="flex rounded-lg bg-white/5 p-1 mb-5">
+            {/* Order type toggle */}
+            <div role="group" aria-label="Order type" className="flex rounded-lg bg-foreground/5 p-1 mb-5">
               {(["LIMIT", "MARKET"] as OrderType[]).map((t) => (
                 <button
                   key={t}
                   onClick={() => setType(t)}
+                  aria-pressed={type === t}
                   className={`flex-1 rounded-md py-1.5 text-sm font-medium transition-all
                     ${type === t
-                      ? "bg-white/15 text-white shadow"
-                      : "text-gray-400 hover:text-white"}`}
+                      ? "bg-foreground/15 text-foreground shadow"
+                      : "text-foreground-muted hover:text-foreground"}`}
                 >
                   {t === "LIMIT" ? "Limit" : "Market"}
                 </button>
@@ -106,95 +109,115 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
             <div className="space-y-4">
               {/* Price row */}
               {type === "LIMIT" ? (
-                <label className="block">
-                  <span className="text-xs text-gray-400 mb-1 block">Limit Price (USDC)</span>
+                <div>
+                  <label htmlFor="limit-price" className="text-xs text-foreground-muted mb-1 block">
+                    Limit Price (USDC)
+                  </label>
                   <input
+                    id="limit-price"
                     type="number"
                     min="0"
                     placeholder="0.00"
                     value={limitPrice}
                     onChange={(e) => setLimitPrice(e.target.value)}
-                    className="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 text-sm"
+                    className="w-full rounded-lg bg-input border border-border px-3 py-2 text-foreground placeholder-foreground-subtle focus:outline-none focus:border-ring text-sm"
                   />
-                </label>
+                </div>
               ) : (
                 <div>
-                  <span className="text-xs text-gray-400 mb-1 block">Current Market Price</span>
-                  <div className="w-full rounded-lg bg-indigo-900/40 border border-indigo-500/30 px-3 py-2 text-indigo-300 text-sm font-mono">
+                  <span className="text-xs text-foreground-muted mb-1 block">Current Market Price</span>
+                  <div className="w-full rounded-lg bg-accent-market/40 border border-accent-market/30 px-3 py-2 text-accent-market text-sm font-mono">
                     ${marketPrice.toFixed(4)} USDC
                   </div>
                 </div>
               )}
 
               {/* Amount */}
-              <label className="block">
-                <span className="text-xs text-gray-400 mb-1 block">Amount (XLM)</span>
+              <div>
+                <label htmlFor="trade-amount" className="text-xs text-foreground-muted mb-1 block">
+                  Amount (XLM)
+                </label>
                 <input
+                  id="trade-amount"
                   type="number"
                   min="0"
                   placeholder="0.00"
                   value={amount}
                   onChange={(e) => setAmount(e.target.value)}
-                  className="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500 text-sm"
+                  className="w-full rounded-lg bg-input border border-border px-3 py-2 text-foreground placeholder-foreground-subtle focus:outline-none focus:border-ring text-sm"
                 />
-              </label>
+              </div>
 
               {/* Total (read-only) */}
               <div>
-                <span className="text-xs text-gray-400 mb-1 block">Total (USDC)</span>
+                <span className="text-xs text-foreground-muted mb-1 block">Total (USDC)</span>
                 <div className={`w-full rounded-lg border px-3 py-2 text-sm font-mono
-                  ${insufficient ? "border-red-500/50 bg-red-900/20 text-red-400" : "border-white/10 bg-white/5 text-white"}`}>
+                  ${insufficient
+                    ? "border-accent-danger/50 bg-accent-danger/10 text-accent-danger"
+                    : "border-border bg-input text-foreground"}`}>
                   ${total.toFixed(4)}
-                  {insufficient && <span className="ml-2 text-xs text-red-400">Insufficient balance</span>}
+                  {insufficient && (
+                    <span className="ml-2 text-xs text-accent-danger">Insufficient balance</span>
+                  )}
                 </div>
               </div>
 
               {/* Stop-loss slider */}
               <div>
-                <div className="flex justify-between text-xs text-gray-400 mb-1">
-                  <span>Stop-Loss</span>
-                  <span className="text-orange-400 font-medium">-{stopLoss}%</span>
+                <div className="flex justify-between text-xs text-foreground-muted mb-1">
+                  <label htmlFor="stop-loss-slider">Stop-Loss</label>
+                  <span className="text-accent-warning font-medium">-{stopLoss}%</span>
                 </div>
                 <input
+                  id="stop-loss-slider"
                   type="range"
                   min={1}
                   max={50}
                   value={stopLoss}
                   onChange={(e) => setStopLoss(Number(e.target.value))}
-                  className="w-full accent-orange-500"
+                  aria-label={`Stop-loss: ${stopLoss}%`}
+                  aria-valuemin={1}
+                  aria-valuemax={50}
+                  aria-valuenow={stopLoss}
+                  className="w-full accent-[hsl(var(--accent-warning))]"
                 />
               </div>
 
               {/* Position limit toggle */}
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-300 flex items-center gap-1">
+                <span id="position-limit-label" className="text-sm text-foreground flex items-center gap-1">
                   Position Limit
-                  <Info size={13} className="text-gray-500" />
+                  <Info size={13} className="text-foreground-subtle" aria-hidden="true" />
                 </span>
                 <button
                   role="switch"
                   aria-checked={positionLimit}
+                  aria-labelledby="position-limit-label"
                   onClick={() => setPositionLimit((v) => !v)}
-                  className={`relative w-10 h-5 rounded-full transition-colors ${positionLimit ? "bg-blue-500" : "bg-white/15"}`}
+                  className={`relative w-10 h-5 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                    ${positionLimit ? "bg-primary" : "bg-foreground/15"}`}
                 >
-                  <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${positionLimit ? "translate-x-5" : ""}`} />
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-foreground shadow transition-transform ${positionLimit ? "translate-x-5" : ""}`}
+                    aria-hidden="true"
+                  />
                 </button>
               </div>
             </div>
 
             {/* Footer metrics */}
-            <div className="mt-5 rounded-lg bg-white/5 border border-white/10 px-4 py-3 grid grid-cols-3 gap-2 text-center text-xs">
+            <div className="mt-5 rounded-lg bg-foreground/5 border border-border px-4 py-3 grid grid-cols-3 gap-2 text-center text-xs">
               <div>
-                <p className="text-gray-500">Network Fee</p>
-                <p className="text-gray-200 font-medium mt-0.5">{networkFee}</p>
+                <p className="text-foreground-subtle">Network Fee</p>
+                <p className="text-foreground font-medium mt-0.5">{networkFee}</p>
               </div>
               <div>
-                <p className="text-gray-500">Price Impact</p>
-                <p className="text-yellow-400 font-medium mt-0.5">{priceImpact}</p>
+                <p className="text-foreground-subtle">Price Impact</p>
+                <p className="text-accent-warning font-medium mt-0.5">{priceImpact}</p>
               </div>
               <div>
-                <p className="text-gray-500">Execution</p>
-                <p className="text-gray-200 font-medium mt-0.5">{execMethod}</p>
+                <p className="text-foreground-subtle">Execution</p>
+                <p className="text-foreground font-medium mt-0.5">{execMethod}</p>
               </div>
             </div>
 
@@ -202,12 +225,13 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
             <button
               onClick={handleConfirm}
               disabled={disabled}
-              className={`mt-4 w-full rounded-xl py-3 text-sm font-semibold transition-all
+              aria-disabled={disabled}
+              className={`mt-4 w-full rounded-xl py-3 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
                 ${disabled
-                  ? "bg-white/10 text-gray-500 cursor-not-allowed"
+                  ? "bg-foreground/10 text-foreground-subtle cursor-not-allowed"
                   : type === "MARKET"
-                    ? "bg-indigo-600 hover:bg-indigo-500 text-white"
-                    : "bg-blue-600 hover:bg-blue-500 text-white"}`}
+                    ? "bg-accent-market hover:opacity-90 text-foreground"
+                    : "bg-primary hover:opacity-90 text-primary-foreground"}`}
             >
               {submitting ? "Submitting…" : `Confirm ${type === "LIMIT" ? "Limit" : "Market"} Order`}
             </button>

--- a/components/TradeSkeleton.tsx
+++ b/components/TradeSkeleton.tsx
@@ -1,29 +1,22 @@
 export function TradeSkeleton() {
   return (
-    <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/5 p-5 space-y-4 animate-pulse">
-      {/* Header row */}
+    <div className="w-full max-w-sm rounded-2xl border border-border bg-surface p-5 space-y-4 animate-pulse">
       <div className="flex items-center justify-between">
-        <div className="h-4 w-24 rounded bg-white/10" />
-        <div className="h-5 w-14 rounded-full bg-white/10" />
+        <div className="h-4 w-24 rounded bg-surface-high" />
+        <div className="h-5 w-14 rounded-full bg-surface-high" />
       </div>
-
-      {/* Chart placeholder */}
-      <div className="h-28 w-full rounded-xl bg-white/10" />
-
-      {/* Metrics row */}
+      <div className="h-28 w-full rounded-xl bg-surface-high" />
       <div className="grid grid-cols-3 gap-3">
         {[...Array(3)].map((_, i) => (
           <div key={i} className="space-y-1.5">
-            <div className="h-3 w-16 rounded bg-white/10" />
-            <div className="h-4 w-12 rounded bg-white/10" />
+            <div className="h-3 w-16 rounded bg-surface-high" />
+            <div className="h-4 w-12 rounded bg-surface-high" />
           </div>
         ))}
       </div>
-
-      {/* Footer */}
       <div className="flex items-center justify-between pt-1">
-        <div className="h-3 w-20 rounded bg-white/10" />
-        <div className="h-8 w-24 rounded-lg bg-white/10" />
+        <div className="h-3 w-20 rounded bg-surface-high" />
+        <div className="h-8 w-24 rounded-lg bg-surface-high" />
       </div>
     </div>
   );

--- a/components/TransactionFailure.tsx
+++ b/components/TransactionFailure.tsx
@@ -17,7 +17,6 @@ export function TransactionFailure({ onRetry }: TransactionFailureProps) {
   const handleRetry = useCallback(() => {
     const input = preservedInput;
     clearError();
-    // Clear preserved input after passing it to the retry handler
     setPreservedInput(null);
     onRetry?.(input);
   }, [clearError, preservedInput, setPreservedInput, onRetry]);
@@ -39,64 +38,57 @@ export function TransactionFailure({ onRetry }: TransactionFailureProps) {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
         >
-          {/* Backdrop */}
           <motion.div
-            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            className="absolute inset-0 bg-overlay/50 backdrop-blur-sm"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={handleDismiss}
           />
 
-          {/* Card */}
           <motion.div
-            className="relative w-full max-w-md rounded-2xl border border-red-500/20 bg-gradient-to-b from-zinc-900 to-zinc-950 p-6 shadow-2xl shadow-red-500/10"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tx-failure-title"
+            className="relative w-full max-w-md rounded-2xl border border-accent-danger/20 bg-gradient-to-b from-surface to-background p-6 shadow-2xl"
             initial={{ opacity: 0, scale: 0.9, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
             transition={{ type: "spring", damping: 25, stiffness: 300 }}
           >
-            {/* Close button */}
             <button
               onClick={handleDismiss}
-              className="absolute right-4 top-4 rounded-full p-1 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
+              aria-label="Close"
+              className="absolute right-4 top-4 rounded-full p-1 text-foreground-subtle transition-colors hover:bg-surface-high hover:text-foreground-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <X className="h-4 w-4" />
+              <X className="h-4 w-4" aria-hidden="true" />
             </button>
 
-            {/* Failure animation */}
             <div className="mb-4 flex justify-center">
               <motion.div
                 initial={{ scale: 0 }}
                 animate={{ scale: 1 }}
-                transition={{
-                  type: "spring",
-                  stiffness: 200,
-                  damping: 15,
-                  delay: 0.1,
-                }}
+                transition={{ type: "spring", stiffness: 200, damping: 15, delay: 0.1 }}
               >
                 <div className="relative">
-                  {/* Glow ring */}
                   <motion.div
-                    className="absolute -inset-2 rounded-full bg-red-500/20 blur-xl"
+                    className="absolute -inset-2 rounded-full bg-accent-danger/20 blur-xl"
                     animate={{ scale: [1, 1.15, 1] }}
                     transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
                   />
-                  {/* Shake animation on the icon */}
                   <motion.div
                     animate={{ rotate: [0, -8, 8, -8, 0] }}
                     transition={{ duration: 0.5, delay: 0.3 }}
                   >
-                    <AlertTriangle className="relative h-14 w-14 text-red-400" />
+                    <AlertTriangle className="relative h-14 w-14 text-accent-danger" />
                   </motion.div>
                 </div>
               </motion.div>
             </div>
 
-            {/* Title */}
             <motion.h2
-              className="mb-1 text-center text-xl font-semibold text-white"
+              id="tx-failure-title"
+              className="mb-1 text-center text-xl font-semibold text-foreground"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2 }}
@@ -104,7 +96,7 @@ export function TransactionFailure({ onRetry }: TransactionFailureProps) {
               Transaction Failed
             </motion.h2>
             <motion.p
-              className="mb-6 text-center text-sm text-zinc-400"
+              className="mb-6 text-center text-sm text-foreground-muted"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.25 }}
@@ -112,30 +104,28 @@ export function TransactionFailure({ onRetry }: TransactionFailureProps) {
               {error.message || "Something went wrong during the trade execution."}
             </motion.p>
 
-            {/* Error details */}
             {(error.reason || error.code) && (
               <motion.div
-                className="mb-6 space-y-2 rounded-xl bg-red-950/30 border border-red-500/10 p-4"
+                className="mb-6 space-y-2 rounded-xl bg-accent-danger/10 border border-accent-danger/10 p-4"
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.3 }}
               >
                 {error.code && (
                   <div className="flex items-center justify-between">
-                    <span className="text-xs text-zinc-500">Error Code</span>
-                    <span className="text-xs font-mono text-red-300">{error.code}</span>
+                    <span className="text-xs text-foreground-subtle">Error Code</span>
+                    <span className="text-xs font-mono text-accent-danger">{error.code}</span>
                   </div>
                 )}
                 {error.reason && (
                   <div className="flex items-start justify-between gap-4">
-                    <span className="text-xs text-zinc-500 shrink-0">Reason</span>
-                    <span className="text-xs text-right text-zinc-300">{error.reason}</span>
+                    <span className="text-xs text-foreground-subtle shrink-0">Reason</span>
+                    <span className="text-xs text-right text-foreground-muted">{error.reason}</span>
                   </div>
                 )}
               </motion.div>
             )}
 
-            {/* Actions */}
             <motion.div
               className="flex flex-col gap-2 sm:flex-row"
               initial={{ opacity: 0, y: 10 }}
@@ -144,16 +134,12 @@ export function TransactionFailure({ onRetry }: TransactionFailureProps) {
             >
               <Button
                 onClick={handleRetry}
-                className="flex-1 gap-2 bg-red-600 text-white hover:bg-red-500"
+                className="flex-1 gap-2 bg-accent-danger text-foreground hover:opacity-90"
               >
                 <RefreshCw className="h-4 w-4" />
                 Retry
               </Button>
-              <Button
-                onClick={handleDismiss}
-                variant="outline"
-                className="flex-1 gap-2 border-zinc-700 text-zinc-300 hover:bg-zinc-800 hover:text-white"
-              >
+              <Button onClick={handleDismiss} variant="outline" className="flex-1 gap-2">
                 Dismiss
               </Button>
             </motion.div>

--- a/components/TransactionSuccess.tsx
+++ b/components/TransactionSuccess.tsx
@@ -13,15 +13,11 @@ export function TransactionSuccess() {
 
   const handleViewPortfolio = useCallback(() => {
     clearSuccess();
-    // Navigate to portfolio - placeholder for now
     console.log("Navigate to portfolio");
   }, [clearSuccess]);
 
-  const handleContinueSwiping = useCallback(() => {
-    clearSuccess();
-  }, [clearSuccess]);
+  const handleContinueSwiping = useCallback(() => clearSuccess(), [clearSuccess]);
 
-  // Auto-dismiss
   useEffect(() => {
     if (!showSuccess) return;
     const timer = setTimeout(clearSuccess, AUTO_DISMISS_MS);
@@ -42,58 +38,52 @@ export function TransactionSuccess() {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
         >
-          {/* Backdrop */}
           <motion.div
-            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            className="absolute inset-0 bg-overlay/50 backdrop-blur-sm"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={clearSuccess}
           />
 
-          {/* Card */}
           <motion.div
-            className="relative w-full max-w-md rounded-2xl border border-emerald-500/20 bg-gradient-to-b from-zinc-900 to-zinc-950 p-6 shadow-2xl shadow-emerald-500/10"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tx-success-title"
+            className="relative w-full max-w-md rounded-2xl border border-accent-success/20 bg-gradient-to-b from-surface to-background p-6 shadow-2xl"
             initial={{ opacity: 0, scale: 0.9, y: 20 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
             transition={{ type: "spring", damping: 25, stiffness: 300 }}
           >
-            {/* Close button */}
             <button
               onClick={clearSuccess}
-              className="absolute right-4 top-4 rounded-full p-1 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
+              aria-label="Close"
+              className="absolute right-4 top-4 rounded-full p-1 text-foreground-subtle transition-colors hover:bg-surface-high hover:text-foreground-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <X className="h-4 w-4" />
+              <X className="h-4 w-4" aria-hidden="true" />
             </button>
 
-            {/* Success animation */}
             <div className="mb-4 flex justify-center">
               <motion.div
                 initial={{ scale: 0 }}
                 animate={{ scale: 1 }}
-                transition={{
-                  type: "spring",
-                  stiffness: 200,
-                  damping: 15,
-                  delay: 0.1,
-                }}
+                transition={{ type: "spring", stiffness: 200, damping: 15, delay: 0.1 }}
               >
                 <div className="relative">
-                  {/* Glow ring */}
                   <motion.div
-                    className="absolute -inset-2 rounded-full bg-emerald-500/20 blur-xl"
+                    className="absolute -inset-2 rounded-full bg-accent-success/20 blur-xl"
                     animate={{ scale: [1, 1.15, 1] }}
                     transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
                   />
-                  <CheckCircle className="relative h-14 w-14 text-emerald-400" />
+                  <CheckCircle className="relative h-14 w-14 text-accent-success" />
                 </div>
               </motion.div>
             </div>
 
-            {/* Title */}
             <motion.h2
-              className="mb-1 text-center text-xl font-semibold text-white"
+              id="tx-success-title"
+              className="mb-1 text-center text-xl font-semibold text-foreground"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2 }}
@@ -101,7 +91,7 @@ export function TransactionSuccess() {
               Trade Executed
             </motion.h2>
             <motion.p
-              className="mb-6 text-center text-sm text-zinc-400"
+              className="mb-6 text-center text-sm text-foreground-muted"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.25 }}
@@ -109,9 +99,8 @@ export function TransactionSuccess() {
               Your swap completed successfully
             </motion.p>
 
-            {/* Transaction details */}
             <motion.div
-              className="mb-6 space-y-3 rounded-xl bg-zinc-800/50 p-4"
+              className="mb-6 space-y-3 rounded-xl bg-surface-high p-4"
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.3 }}
@@ -120,13 +109,13 @@ export function TransactionSuccess() {
               <DetailRow label="Amount" value={success.amount} />
               <DetailRow label="Price" value={success.price} />
               <DetailRow label="Fee" value={success.fee} />
-              <div className="flex items-center justify-between border-t border-zinc-700/50 pt-3">
-                <span className="text-xs text-zinc-500">Transaction</span>
+              <div className="flex items-center justify-between border-t border-border pt-3">
+                <span className="text-xs text-foreground-subtle">Transaction</span>
                 <a
                   href={`https://stellar.expert/explorer/testnet/tx/${success.hash}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex items-center gap-1 text-xs font-mono text-emerald-400 transition-colors hover:text-emerald-300"
+                  className="flex items-center gap-1 text-xs font-mono text-accent-success transition-colors hover:opacity-80"
                 >
                   {truncatedHash}
                   <ArrowRight className="h-3 w-3" />
@@ -134,7 +123,6 @@ export function TransactionSuccess() {
               </div>
             </motion.div>
 
-            {/* Actions */}
             <motion.div
               className="flex flex-col gap-2 sm:flex-row"
               initial={{ opacity: 0, y: 10 }}
@@ -143,7 +131,7 @@ export function TransactionSuccess() {
             >
               <Button
                 onClick={handleViewPortfolio}
-                className="flex-1 gap-2 bg-emerald-600 text-white hover:bg-emerald-500"
+                className="flex-1 gap-2 bg-accent-success text-foreground hover:opacity-90"
               >
                 <Eye className="h-4 w-4" />
                 View Portfolio
@@ -151,7 +139,7 @@ export function TransactionSuccess() {
               <Button
                 onClick={handleContinueSwiping}
                 variant="outline"
-                className="flex-1 gap-2 border-zinc-700 text-zinc-300 hover:bg-zinc-800 hover:text-white"
+                className="flex-1 gap-2"
               >
                 Continue Swiping
                 <ArrowRight className="h-4 w-4" />
@@ -167,8 +155,8 @@ export function TransactionSuccess() {
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-xs text-zinc-500">{label}</span>
-      <span className="text-sm font-medium text-zinc-200">{value}</span>
+      <span className="text-xs text-foreground-subtle">{label}</span>
+      <span className="text-sm font-medium text-foreground">{value}</span>
     </div>
   );
 }

--- a/components/signal/SignalFeed.tsx
+++ b/components/signal/SignalFeed.tsx
@@ -32,9 +32,7 @@ export function SignalFeed() {
       const response = await fetch(`/api/signals?page=${pageParam}&pageSize=${PAGE_SIZE}`, {
         cache: "no-store",
       });
-      if (!response.ok) {
-        throw new Error("Unable to load the signal feed.");
-      }
+      if (!response.ok) throw new Error("Unable to load the signal feed.");
       return response.json() as Promise<SignalResponse>;
     },
     getNextPageParam: (lastPage: SignalResponse) => lastPage.nextPage,
@@ -50,71 +48,59 @@ export function SignalFeed() {
   const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   const loadMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   useEffect(() => {
     const element = sentinelRef.current;
-    if (!element || !hasNextPage || isFetchingNextPage) {
-      return;
-    }
-
+    if (!element || !hasNextPage || isFetchingNextPage) return;
     const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          loadMore();
-        }
-      },
-      {
-        rootMargin: "240px",
-      }
+      (entries) => { if (entries[0]?.isIntersecting) loadMore(); },
+      { rootMargin: "240px" }
     );
-
     observer.observe(element);
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, loadMore]);
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/80 p-6 shadow-xl shadow-slate-950/10">
+    <section className="rounded-3xl border border-border bg-surface/80 p-6 shadow-xl">
       <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-sm uppercase tracking-[0.3em] text-sky-400/90">Signal feed</p>
-          <h2 className="text-3xl font-semibold">Live market signals</h2>
-          <p className="max-w-2xl text-sm text-slate-400">
+          <p className="text-sm uppercase tracking-[0.3em] text-accent-sky">Signal feed</p>
+          <h2 className="text-3xl font-semibold text-foreground">Live market signals</h2>
+          <p className="max-w-2xl text-sm text-foreground-muted">
             Browse the latest actionable signals with seamless infinite scrolling.
           </p>
         </div>
-        <div className="text-right text-sm text-slate-400">
+        <div className="text-right text-sm text-foreground-muted">
           {isFetching && !signals.length ? "Loading signals..." : "Scroll down to load more."}
         </div>
       </div>
 
       <div className="space-y-4">
-        {isError ? (
-          <div className="rounded-3xl border border-rose-200/20 bg-rose-50/10 p-5 text-sm text-rose-200">
+        {isError && (
+          <div className="rounded-3xl border border-accent-danger/20 bg-accent-danger/10 p-5 text-sm text-accent-danger">
             {error?.message ?? "There was a problem loading the signal feed."}
           </div>
-        ) : null}
+        )}
 
-        {!isLoading && signals.length === 0 ? (
-          <div className="rounded-3xl border border-slate-700/80 bg-slate-950/80 p-8 text-center text-slate-300">
+        {!isLoading && signals.length === 0 && (
+          <div className="rounded-3xl border border-border bg-surface/80 p-8 text-center text-foreground-muted">
             No signals available right now.
           </div>
-        ) : null}
+        )}
 
         {isLoading ? (
           <div className="space-y-4">
             {Array.from({ length: 3 }).map((_, index) => (
               <div
                 key={index}
-                className="animate-pulse rounded-3xl border border-white/10 bg-slate-900/80 p-6"
+                className="animate-pulse rounded-3xl border border-border bg-surface p-6"
               >
-                <div className="mb-4 h-6 w-3/5 rounded-xl bg-slate-700" />
+                <div className="mb-4 h-6 w-3/5 rounded-xl bg-surface-high" />
                 <div className="grid gap-3 sm:grid-cols-2">
-                  <div className="h-5 rounded-xl bg-slate-700" />
-                  <div className="h-5 rounded-xl bg-slate-700" />
+                  <div className="h-5 rounded-xl bg-surface-high" />
+                  <div className="h-5 rounded-xl bg-surface-high" />
                 </div>
               </div>
             ))}
@@ -123,22 +109,22 @@ export function SignalFeed() {
           signals.map((signal) => (
             <article
               key={signal.id}
-              className="rounded-3xl border border-white/10 bg-slate-950/90 p-6 shadow-sm shadow-slate-950/20 transition hover:-translate-y-0.5"
+              className="rounded-3xl border border-border bg-surface p-6 shadow-sm transition hover:-translate-y-0.5"
             >
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                  <p className="text-xs uppercase tracking-[0.3em] text-foreground-muted">
                     {new Date(signal.timestamp).toLocaleString()}
                   </p>
-                  <h3 className="mt-2 text-xl font-semibold tracking-tight text-white">
+                  <h3 className="mt-2 text-xl font-semibold tracking-tight text-foreground">
                     {signal.ticker} • {signal.action}
                   </h3>
                 </div>
-                <div className="rounded-full border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-sky-300">
+                <div className="rounded-full border border-border bg-surface-high px-4 py-2 text-sm font-semibold text-accent-sky">
                   Confidence {signal.confidence}%
                 </div>
               </div>
-              <p className="mt-4 text-sm leading-6 text-slate-300">{signal.details}</p>
+              <p className="mt-4 text-sm leading-6 text-foreground-muted">{signal.details}</p>
             </article>
           ))
         )}
@@ -147,27 +133,23 @@ export function SignalFeed() {
       <div className="mt-6 flex flex-col items-center gap-4">
         <div ref={sentinelRef} className="h-1 w-full" />
 
-        {isFetchingNextPage ? (
-          <div className="rounded-full border border-slate-700 bg-slate-900 px-4 py-2 text-sm text-slate-300">
+        {isFetchingNextPage && (
+          <div className="rounded-full border border-border bg-surface px-4 py-2 text-sm text-foreground-muted">
             Loading more signals...
           </div>
-        ) : null}
+        )}
 
-        {!hasNextPage && signals.length > 0 ? (
-          <p className="text-center text-sm text-slate-500">
-            You’ve reached the end of the feed.
+        {!hasNextPage && signals.length > 0 && (
+          <p className="text-center text-sm text-foreground-subtle">
+            You&apos;ve reached the end of the feed.
           </p>
-        ) : null}
+        )}
 
-        {hasNextPage ? (
-          <Button
-            variant="outline"
-            onClick={loadMore}
-            disabled={isFetchingNextPage}
-          >
+        {hasNextPage && (
+          <Button variant="outline" onClick={loadMore} disabled={isFetchingNextPage}>
             {isFetchingNextPage ? "Loading more..." : "Load more signals"}
           </Button>
-        ) : null}
+        )}
       </div>
     </section>
   );

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -46,7 +46,7 @@ const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
           "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           "disabled:pointer-events-none disabled:opacity-50",
           // Copied state
-          copied && "border-green-500/40 bg-green-500/10 text-green-600 dark:text-green-400",
+          copied && "border-accent-success/40 bg-accent-success/10 text-accent-success",
           className
         )}
         {...props}

--- a/components/ui/stop-loss-slider.tsx
+++ b/components/ui/stop-loss-slider.tsx
@@ -66,17 +66,17 @@ export function StopLossSlider({
   // Colour the thumb/track based on risk level
   const riskColor =
     value <= 10
-      ? "text-green-500"
+      ? "text-accent-success"
       : value <= 30
-      ? "text-yellow-500"
-      : "text-red-500";
+      ? "text-accent-warning"
+      : "text-accent-danger";
 
   const trackFillColor =
     value <= 10
-      ? "bg-green-500"
+      ? "bg-accent-success"
       : value <= 30
-      ? "bg-yellow-500"
-      : "bg-red-500";
+      ? "bg-accent-warning"
+      : "bg-accent-danger";
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
@@ -147,19 +147,19 @@ export function StopLossSlider({
             "[&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:duration-100",
             "[&::-webkit-slider-thumb]:hover:scale-110",
             value <= 10
-              ? "[&::-webkit-slider-thumb]:bg-green-500"
+              ? "[&::-webkit-slider-thumb]:bg-[hsl(var(--accent-success))]"
               : value <= 30
-              ? "[&::-webkit-slider-thumb]:bg-yellow-500"
-              : "[&::-webkit-slider-thumb]:bg-red-500",
+              ? "[&::-webkit-slider-thumb]:bg-[hsl(var(--accent-warning))]"
+              : "[&::-webkit-slider-thumb]:bg-[hsl(var(--accent-danger))]",
             // Firefox
             "[&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4",
             "[&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2",
             "[&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:shadow-md",
             value <= 10
-              ? "[&::-moz-range-thumb]:bg-green-500"
+              ? "[&::-moz-range-thumb]:bg-[hsl(var(--accent-success))]"
               : value <= 30
-              ? "[&::-moz-range-thumb]:bg-yellow-500"
-              : "[&::-moz-range-thumb]:bg-red-500",
+              ? "[&::-moz-range-thumb]:bg-[hsl(var(--accent-warning))]"
+              : "[&::-moz-range-thumb]:bg-[hsl(var(--accent-danger))]",
             // Focus ring on thumb
             "focus-visible:[&::-webkit-slider-thumb]:ring-2",
             "focus-visible:[&::-webkit-slider-thumb]:ring-ring",

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -6,9 +6,9 @@ import { useToastStore, type ToastMessage } from "@/store/useToastStore";
 import { cn } from "@/lib/utils";
 
 const toneStyles: Record<ToastMessage["tone"], string> = {
-  success: "border-emerald-300 bg-emerald-50 text-emerald-900 shadow-sm",
-  error: "border-rose-300 bg-rose-50 text-rose-900 shadow-sm",
-  info: "border-sky-300 bg-sky-50 text-sky-900 shadow-sm",
+  success: "border-accent-success/30 bg-accent-success/10 text-foreground shadow-sm",
+  error:   "border-accent-danger/30  bg-accent-danger/10  text-foreground shadow-sm",
+  info:    "border-accent-sky/30     bg-accent-sky/10     text-foreground shadow-sm",
 };
 
 const toneIcons: Record<ToastMessage["tone"], typeof CheckCircle2> = {
@@ -48,7 +48,7 @@ export function ToastProvider() {
               )}
             >
               <div className="flex items-start gap-3">
-                <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-white/80 text-current shadow-sm">
+                <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-foreground/10 text-current shadow-sm">
                   <Icon className="h-4 w-4" aria-hidden="true" />
                 </div>
 
@@ -64,7 +64,7 @@ export function ToastProvider() {
                 <button
                   type="button"
                   aria-label="Dismiss notification"
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-current transition hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50"
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-current transition hover:bg-foreground/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/50"
                   onClick={() => dismiss(toast.id)}
                 >
                   <X className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
closes #33
- globals.css: replace shadcn defaults with dark-first token system (background, surface, surface-high, overlay, foreground-muted, foreground-subtle, border-strong, accent-sky/success/danger/warning/market)
- layout.tsx: add class="dark" to <html> — app is dark-only
- All components: replace every hardcoded palette class (slate-*, zinc-*, gray-*, white/*, indigo-*, emerald-*, red-*, green-*, yellow-*) with semantic tokens (bg-surface, text-foreground-muted, text-accent-sky, etc.) across TradeModal, TransactionSuccess, TransactionFailure, TradeSkeleton, PositionLimitToggle, SignalBadge, SignalFeed, stop-loss-slider, copy-button, toast
- Zero raw palette colors remain in component files