### PR TITLE
Execute Trade Button Flow

### DIFF
--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { TrendingUp, TrendingDown, Minus, X, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SignalBadge } from "@/components/SignalBadge";
 import { SignalTimestamp } from "@/components/SignalTimestamp";
 import { TradeSkeleton } from "@/components/TradeSkeleton";
+import { TradeModal } from "@/components/TradeModal";
 import { cn } from "@/lib/utils";
 
 interface ROIPoint {
@@ -82,6 +83,8 @@ export function SignalCard({
   onPass,
 }: SignalCardProps) {
   const [passed, setPassed] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const executingRef = useRef(false);
 
   if (loading) return <TradeSkeleton />;
   if (passed) return null;
@@ -95,13 +98,30 @@ export function SignalCard({
     onPass?.();
   }
 
+  function handleExecuteTrade() {
+    if (executingRef.current) return;
+    executingRef.current = true;
+    setModalOpen(true);
+  }
+
+  function handleModalClose() {
+    setModalOpen(false);
+    executingRef.current = false;
+  }
+
+  function handleModalConfirm() {
+    setModalOpen(false);
+    executingRef.current = false;
+    onTrade?.(executionPrice);
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
       e.preventDefault();
       if (e.key === "ArrowLeft") {
         handlePass();
       } else {
-        onTrade?.(executionPrice);
+        handleExecuteTrade();
       }
     }
   };
@@ -169,14 +189,22 @@ export function SignalCard({
         </Button>
         <Button
           size="sm"
-          onClick={() => onTrade?.(executionPrice)}
-          className="flex-1"
-          aria-label={`Trade ${signal} signal for ${pair} at ${executionPrice}`}
+          onClick={handleExecuteTrade}
+          disabled={modalOpen}
+          className="flex-1 active:scale-95"
+          aria-label={`Execute trade: ${signal} signal for ${pair} at ${executionPrice}`}
         >
           <Zap size={16} className="mr-1" />
-          Trade
+          Execute Trade
         </Button>
       </div>
+
+      <TradeModal
+        open={modalOpen}
+        onClose={handleModalClose}
+        onConfirm={handleModalConfirm}
+        marketPrice={executionPrice}
+      />
     </article>
   );
 }

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -10,6 +10,7 @@ type OrderType = "LIMIT" | "MARKET";
 interface TradeModalProps {
   open: boolean;
   onClose: () => void;
+  onConfirm?: () => void;
   walletBalance?: number;
   marketPrice?: number;
 }
@@ -25,7 +26,7 @@ function validateField(value: string, label: string): string {
   return "";
 }
 
-export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0.4821 }: TradeModalProps) {
+export function TradeModal({ open, onClose, onConfirm, walletBalance = 250, marketPrice = 0.4821 }: TradeModalProps) {
   const [type, setType] = useState<OrderType>("LIMIT");
   const [limitPrice, setLimitPrice] = useState("");
   const [amount, setAmount] = useState("");
@@ -60,8 +61,8 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
     setSubmitting(true);
     await mockBuildTx({ type, price, amount, stopLoss, positionLimit });
     setSubmitting(false);
-    onClose();
-  }, [type, price, amount, stopLoss, positionLimit, onClose]);
+    onConfirm ? onConfirm() : onClose();
+  }, [type, price, amount, stopLoss, positionLimit, onClose, onConfirm]);
 
   const networkFee = "0.00001 XLM";
   const priceImpact = type === "MARKET" ? "~0.12%" : "~0.05%";


### PR DESCRIPTION
closes #26 


This PR implements the Execute Trade button as a desktop-friendly alternative to swipe interactions, providing a consistent execution flow across devices. The button opens the trade confirmation modal on click, includes proper hover/active/disabled states, and prevents duplicate execution from double-clicks.

Changes:
Added Execute Trade button for desktop workflows
Wired button click to open the confirmation modal
Implemented hover, active, and disabled button states
Added protection against double-click / duplicate execution
Aligned behavior with existing swipe-right trade flow