### PR TITLE
Signal Card Swipe Interaction (Desktop + Mobile)

### DIFF
--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState, useRef } from "react";
-import { TrendingUp, TrendingDown, Minus, X, Zap } from "lucide-react";
+import {
+  motion,
+  useMotionValue,
+  useTransform,
+  AnimatePresence,
+} from "framer-motion";
+import { TrendingUp, TrendingDown, Minus, X, Zap, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SignalBadge } from "@/components/SignalBadge";
 import { SignalTimestamp } from "@/components/SignalTimestamp";
@@ -69,6 +75,8 @@ const DEFAULT_ROI: ROIPoint[] = [
   { value: 1.9 }, { value: 3.4 }, { value: 2.8 }, { value: 4.2 },
 ];
 
+const SWIPE_THRESHOLD = 120;
+
 export function SignalCard({
   loading = false,
   pair = "XLM/USDC",
@@ -82,19 +90,25 @@ export function SignalCard({
   onTrade,
   onPass,
 }: SignalCardProps) {
-  const [passed, setPassed] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const executingRef = useRef(false);
 
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-300, 300], [-18, 18]);
+
+  // Overlay opacities — ramp up after 30px, full at threshold
+  const tradeOpacity = useTransform(x, [30, SWIPE_THRESHOLD], [0, 1]);
+  const passOpacity = useTransform(x, [-30, -SWIPE_THRESHOLD], [0, 1]);
+
   if (loading) return <TradeSkeleton />;
-  if (passed) return null;
 
   const roi = (((projectedTarget - executionPrice) / executionPrice) * 100).toFixed(2);
   const isPositive = parseFloat(roi) >= 0;
   const DirectionIcon = signal === "BUY" ? TrendingUp : signal === "SELL" ? TrendingDown : Minus;
 
   function handlePass() {
-    setPassed(true);
+    setDismissed(true);
     onPass?.();
   }
 
@@ -115,96 +129,142 @@ export function SignalCard({
     onTrade?.(executionPrice);
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
       e.preventDefault();
-      if (e.key === "ArrowLeft") {
-        handlePass();
-      } else {
-        handleExecuteTrade();
-      }
+      if (e.key === "ArrowLeft") handlePass();
+      else handleExecuteTrade();
     }
-  };
+  }
+
+  function handleDragEnd(_: unknown, info: { offset: { x: number } }) {
+    if (info.offset.x > SWIPE_THRESHOLD) {
+      handleExecuteTrade();
+    } else if (info.offset.x < -SWIPE_THRESHOLD) {
+      handlePass();
+    }
+    // spring back handled by dragSnapToOrigin
+  }
 
   return (
-    <article 
-      className="w-full rounded-2xl border bg-card p-4 shadow-sm flex flex-col gap-3 sm:p-5 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 focus-within:ring-offset-background"
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
-      role="article"
-      aria-label={`${signal} signal for ${pair} at ${executionPrice} with ${confidence}% confidence`}
-    >
-      <div className="flex items-center justify-between">
-        <span className="font-semibold text-base sm:text-lg">{pair}</span>
-        <SignalBadge signal={signal} />
-      </div>
-
-      <div className="grid grid-cols-2 gap-3 text-sm">
-        <div>
-          <p className="text-muted-foreground">Execution Price</p>
-          <p className="font-mono font-semibold">${executionPrice.toFixed(4)}</p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Confidence</p>
-          <p className="font-semibold">{confidence}%</p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">Target</p>
-          <p className="font-mono font-semibold">${projectedTarget.toFixed(4)}</p>
-        </div>
-        <div>
-          <p className="text-muted-foreground">ROI</p>
-          <p className={cn("font-semibold", isPositive ? "text-green-600" : "text-red-600")}>
-            {isPositive ? "+" : ""}{roi}%
-          </p>
-        </div>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <DirectionIcon size={16} className={cn(
-          signal === "BUY" ? "text-green-600" : signal === "SELL" ? "text-red-600" : "text-gray-500"
-        )} />
-        <MiniROIChart data={roiHistory} />
-      </div>
-
-      <p className="text-sm text-muted-foreground leading-relaxed">{analysis}</p>
-
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <SignalTimestamp updatedAt={timestamp} />
-        <p className="text-xs text-muted-foreground">
-          Use ← to pass, → to trade, or buttons below
-        </p>
-      </div>
-
-      <div className="flex gap-2 pt-2">
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handlePass}
-          className="flex-1"
-          aria-label={`Pass on ${signal} signal for ${pair}`}
+    <AnimatePresence>
+      {!dismissed && (
+        <motion.div
+          className="relative w-full touch-none select-none"
+          style={{ x, rotate }}
+          drag="x"
+          dragSnapToOrigin
+          dragElastic={0.15}
+          dragConstraints={{ left: 0, right: 0 }}
+          onDragEnd={handleDragEnd}
+          exit={{ x: 0, opacity: 0, scale: 0.85, transition: { duration: 0.25 } }}
+          whileTap={{ cursor: "grabbing" }}
         >
-          <X size={16} className="mr-1" />
-          Pass
-        </Button>
-        <Button
-          size="sm"
-          onClick={handleExecuteTrade}
-          disabled={modalOpen}
-          className="flex-1 active:scale-95"
-          aria-label={`Execute trade: ${signal} signal for ${pair} at ${executionPrice}`}
-        >
-          <Zap size={16} className="mr-1" />
-          Execute Trade
-        </Button>
-      </div>
+          {/* TRADE overlay */}
+          <motion.div
+            className="pointer-events-none absolute inset-0 z-10 flex items-center justify-start rounded-2xl border-2 border-green-500 bg-green-500/10 pl-6"
+            style={{ opacity: tradeOpacity }}
+            aria-hidden="true"
+          >
+            <span className="flex items-center gap-1.5 rounded-lg bg-green-500 px-3 py-1.5 text-sm font-bold text-white shadow">
+              <Check size={15} />
+              TRADE
+            </span>
+          </motion.div>
 
-      <TradeModal
-        open={modalOpen}
-        onClose={handleModalClose}
-        onConfirm={handleModalConfirm}
-        marketPrice={executionPrice}
-      />
-    </article>
+          {/* PASS overlay */}
+          <motion.div
+            className="pointer-events-none absolute inset-0 z-10 flex items-center justify-end rounded-2xl border-2 border-red-500 bg-red-500/10 pr-6"
+            style={{ opacity: passOpacity }}
+            aria-hidden="true"
+          >
+            <span className="flex items-center gap-1.5 rounded-lg bg-red-500 px-3 py-1.5 text-sm font-bold text-white shadow">
+              <X size={15} />
+              PASS
+            </span>
+          </motion.div>
+
+          <article
+            className="w-full rounded-2xl border bg-card p-4 shadow-sm flex flex-col gap-3 sm:p-5 focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 focus-within:ring-offset-background"
+            tabIndex={0}
+            onKeyDown={handleKeyDown}
+            role="article"
+            aria-label={`${signal} signal for ${pair} at ${executionPrice} with ${confidence}% confidence`}
+          >
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-base sm:text-lg">{pair}</span>
+              <SignalBadge signal={signal} />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p className="text-muted-foreground">Execution Price</p>
+                <p className="font-mono font-semibold">${executionPrice.toFixed(4)}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Confidence</p>
+                <p className="font-semibold">{confidence}%</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Target</p>
+                <p className="font-mono font-semibold">${projectedTarget.toFixed(4)}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">ROI</p>
+                <p className={cn("font-semibold", isPositive ? "text-green-600" : "text-red-600")}>
+                  {isPositive ? "+" : ""}{roi}%
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <DirectionIcon size={16} className={cn(
+                signal === "BUY" ? "text-green-600" : signal === "SELL" ? "text-red-600" : "text-gray-500"
+              )} />
+              <MiniROIChart data={roiHistory} />
+            </div>
+
+            <p className="text-sm text-muted-foreground leading-relaxed">{analysis}</p>
+
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <SignalTimestamp updatedAt={timestamp} />
+              <p className="text-xs text-muted-foreground">
+                Swipe or use ← → keys
+              </p>
+            </div>
+
+            <div className="flex gap-2 pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePass}
+                className="flex-1"
+                aria-label={`Pass on ${signal} signal for ${pair}`}
+              >
+                <X size={16} className="mr-1" />
+                Pass
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleExecuteTrade}
+                disabled={modalOpen}
+                className="flex-1 active:scale-95"
+                aria-label={`Execute trade: ${signal} signal for ${pair} at ${executionPrice}`}
+              >
+                <Zap size={16} className="mr-1" />
+                Execute Trade
+              </Button>
+            </div>
+          </article>
+
+          <TradeModal
+            open={modalOpen}
+            onClose={handleModalClose}
+            onConfirm={handleModalConfirm}
+            marketPrice={executionPrice}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { TrendingUp, TrendingDown, Minus, X, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SignalBadge } from "@/components/SignalBadge";
 import { SignalTimestamp } from "@/components/SignalTimestamp";
 import { TradeSkeleton } from "@/components/TradeSkeleton";
+import { TradeModal } from "@/components/TradeModal";
 import { cn } from "@/lib/utils";
 
 interface ROIPoint {
@@ -82,6 +83,8 @@ export function SignalCard({
   onPass,
 }: SignalCardProps) {
   const [passed, setPassed] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const executingRef = useRef(false);
 
   if (loading) return <TradeSkeleton />;
   if (passed) return null;
@@ -95,13 +98,30 @@ export function SignalCard({
     onPass?.();
   }
 
+  function handleExecuteTrade() {
+    if (executingRef.current) return;
+    executingRef.current = true;
+    setModalOpen(true);
+  }
+
+  function handleModalClose() {
+    setModalOpen(false);
+    executingRef.current = false;
+  }
+
+  function handleModalConfirm() {
+    setModalOpen(false);
+    executingRef.current = false;
+    onTrade?.(executionPrice);
+  }
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
       e.preventDefault();
       if (e.key === "ArrowLeft") {
         handlePass();
       } else {
-        onTrade?.(executionPrice);
+        handleExecuteTrade();
       }
     }
   };
@@ -169,14 +189,22 @@ export function SignalCard({
         </Button>
         <Button
           size="sm"
-          onClick={() => onTrade?.(executionPrice)}
-          className="flex-1"
-          aria-label={`Trade ${signal} signal for ${pair} at ${executionPrice}`}
+          onClick={handleExecuteTrade}
+          disabled={modalOpen}
+          className="flex-1 active:scale-95"
+          aria-label={`Execute trade: ${signal} signal for ${pair} at ${executionPrice}`}
         >
           <Zap size={16} className="mr-1" />
-          Trade
+          Execute Trade
         </Button>
       </div>
+
+      <TradeModal
+        open={modalOpen}
+        onClose={handleModalClose}
+        onConfirm={handleModalConfirm}
+        marketPrice={executionPrice}
+      />
     </article>
   );
 }

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -10,6 +10,7 @@ type OrderType = "LIMIT" | "MARKET";
 interface TradeModalProps {
   open: boolean;
   onClose: () => void;
+  onConfirm?: () => void;
   walletBalance?: number;
   marketPrice?: number;
 }
@@ -25,7 +26,7 @@ function validateField(value: string, label: string): string {
   return "";
 }
 
-export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0.4821 }: TradeModalProps) {
+export function TradeModal({ open, onClose, onConfirm, walletBalance = 250, marketPrice = 0.4821 }: TradeModalProps) {
   const [type, setType] = useState<OrderType>("LIMIT");
   const [limitPrice, setLimitPrice] = useState("");
   const [amount, setAmount] = useState("");
@@ -60,8 +61,8 @@ export function TradeModal({ open, onClose, walletBalance = 250, marketPrice = 0
     setSubmitting(true);
     await mockBuildTx({ type, price, amount, stopLoss, positionLimit });
     setSubmitting(false);
-    onClose();
-  }, [type, price, amount, stopLoss, positionLimit, onClose]);
+    onConfirm ? onConfirm() : onClose();
+  }, [type, price, amount, stopLoss, positionLimit, onClose, onConfirm]);
 
   const networkFee = "0.00001 XLM";
   const priceImpact = type === "MARKET" ? "~0.12%" : "~0.05%";


### PR DESCRIPTION
closes #12 


This PR adds interactive swipe gestures for signal cards, enabling intuitive accept/reject actions across both mobile and desktop. Users can swipe right to execute and swipe left to dismiss on mobile, while desktop supports drag gestures with a button fallback. Keyboard shortcuts and visual feedback are included for accessibility and a polished interaction experience.

Changes:
Implemented mobile swipe gestures:
Swipe right → execute trade
Swipe left → dismiss signal
Added desktop drag gesture support with button fallback
Added keyboard shortcuts:
Right arrow → accept
Left arrow → reject
Added visual tilt, green/red action feedback, and threshold-based triggers
Implemented smooth animation transitions using framer-motion