### PR TITLE
Empty State for Signal Feed

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import { Navbar } from "@/components/Navbar";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -26,7 +27,10 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <Navbar />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Loader2, Zap } from "lucide-react";
+import { useWallet } from "@/hooks/useWallet";
+import { Button } from "@/components/ui/button";
+import { WalletDropdown } from "@/components/WalletDropdown";
+import { WalletSelectionModal } from "@/components/WalletSelectionModal";
+
+const NAV_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/signals", label: "Signals" },
+  { href: "/providers", label: "Providers" },
+];
+
+export function Navbar() {
+  const { connected, isConnecting } = useWallet();
+  const [walletModalOpen, setWalletModalOpen] = useState(false);
+
+  return (
+    <>
+      <header className="sticky top-0 z-40 w-full border-b border-white/10 bg-gray-950/80 backdrop-blur-md">
+        <nav
+          className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6"
+          aria-label="Main navigation"
+        >
+          {/* Logo */}
+          <Link
+            href="/"
+            className="flex items-center gap-2 font-bold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-md"
+            aria-label="StellarSwipe home"
+          >
+            <Zap className="h-5 w-5 text-blue-400" aria-hidden="true" />
+            <span className="text-sm sm:text-base">StellarSwipe</span>
+          </Link>
+
+          {/* Nav links */}
+          <ul className="hidden sm:flex items-center gap-1" role="list">
+            {NAV_LINKS.map(({ href, label }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="rounded-md px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {/* Wallet CTA */}
+          <div className="flex items-center">
+            {connected ? (
+              <WalletDropdown />
+            ) : (
+              <Button
+                size="sm"
+                disabled={isConnecting}
+                onClick={() => setWalletModalOpen(true)}
+                aria-label={isConnecting ? "Connecting wallet…" : "Connect wallet"}
+                className="gap-2"
+              >
+                {isConnecting && (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                )}
+                {isConnecting ? "Connecting…" : "Connect Wallet"}
+              </Button>
+            )}
+          </div>
+        </nav>
+      </header>
+
+      <WalletSelectionModal
+        open={walletModalOpen}
+        onClose={() => setWalletModalOpen(false)}
+      />
+    </>
+  );
+}

--- a/components/SignalEmptyState.tsx
+++ b/components/SignalEmptyState.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { RadioTower, RefreshCw, Users } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface SignalEmptyStateProps {
+  onRefresh: () => void;
+}
+
+export function SignalEmptyState({ onRefresh }: SignalEmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-white/10 bg-slate-900/60 px-6 py-16 text-center">
+      {/* Icon */}
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-slate-800/80">
+        <RadioTower className="h-8 w-8 text-sky-400/70" aria-hidden="true" />
+      </div>
+
+      {/* Copy */}
+      <div className="max-w-xs">
+        <p className="text-base font-semibold text-white">No signals available right now</p>
+        <p className="mt-1.5 text-sm text-foreground-muted">
+          New signals appear as providers publish them. Follow providers to get notified first.
+        </p>
+      </div>
+
+      {/* CTAs */}
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button size="sm" variant="outline" onClick={onRefresh} className="gap-2">
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          Refresh
+        </Button>
+        <Button size="sm" asChild className="gap-2">
+          <Link href="/providers">
+            <Users className="h-3.5 w-3.5" aria-hidden="true" />
+            Follow Providers
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/signal/SignalFeed.tsx
+++ b/components/signal/SignalFeed.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import type { InfiniteData } from "@tanstack/query-core";
 import { Button } from "@/components/ui/button";
+import { SignalEmptyState } from "@/components/SignalEmptyState";
 import type { Signal } from "@/lib/signals";
 
 interface SignalResponse {
@@ -26,6 +27,7 @@ export function SignalFeed() {
     hasNextPage,
     isFetchingNextPage,
     isFetching,
+    refetch,
   } = useInfiniteQuery<SignalResponse, Error, InfiniteData<SignalResponse, number>>({
     queryKey: ["signals"],
     queryFn: async ({ pageParam = 1 }) => {
@@ -84,10 +86,8 @@ export function SignalFeed() {
           </div>
         )}
 
-        {!isLoading && signals.length === 0 && (
-          <div className="rounded-3xl border border-border bg-surface/80 p-8 text-center text-foreground-muted">
-            No signals available right now.
-          </div>
+        {!isLoading && !isError && signals.length === 0 && (
+          <SignalEmptyState onRefresh={() => refetch()} />
         )}
 
         {isLoading ? (

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -24,7 +24,6 @@ export function useWallet() {
         return;
       }
       await requestAccess();
-      const { address: key } = await getAddress();
       const result = await getAddress();
       const key = typeof result === "string" ? result : result.address;
       setPublicKey(key);


### PR DESCRIPTION
closes #17 


This PR introduces a meaningful empty state for the signal feed when no signals are available, improving user experience and guiding next actions.

Changes Included:
Added empty state UI with illustration/icon
Displayed message: “No signals available right now”
Added CTA actions (e.g., Follow Providers, Refresh)
Integrated with signal feed state logic
Ensured styling aligns with dark theme
Made layout fully responsive