### PR TITLE
feat: Wallet Balance Refresh Button AND Connect Error Modal with Retry

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/components/WalletConnectErrorModal.tsx
+++ b/components/WalletConnectErrorModal.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  X,
+  AlertTriangle,
+  RefreshCw,
+  ExternalLink,
+  CheckCircle2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+
+export type WalletConnectErrorReason =
+  | "not_found"
+  | "error"
+  | null;
+
+interface WalletConnectErrorModalProps {
+  open: boolean;
+  reason: WalletConnectErrorReason;
+  onClose: () => void;
+  onRetry: () => void;
+}
+
+const RECOVERY_STEPS: Record<
+  NonNullable<WalletConnectErrorReason>,
+  { title: string; description: string; steps: string[] }
+> = {
+  not_found: {
+    title: "Freighter Not Found",
+    description:
+      "The Freighter wallet extension was not detected in your browser.",
+    steps: [
+      "Install the Freighter extension from freighter.app",
+      "Refresh this page after installation",
+      "Click \u201cConnect Wallet\u201d and try again",
+    ],
+  },
+  error: {
+    title: "Connection Failed",
+    description:
+      "An unexpected error occurred while connecting to your Freighter wallet.",
+    steps: [
+      "Ensure Freighter is unlocked and up to date",
+      "Check that you are on a supported network",
+      "Disable other wallet extensions that may conflict",
+      "Try again — if the issue persists, reload the page",
+    ],
+  },
+};
+
+export function WalletConnectErrorModal({
+  open,
+  reason,
+  onClose,
+  onRetry,
+}: WalletConnectErrorModalProps) {
+  const focusTrapRef = useFocusTrap({
+    isActive: open,
+    initialFocus: '[data-autofocus="true"]',
+  });
+
+  // ESC to close
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  const content = reason ? RECOVERY_STEPS[reason] : null;
+
+  return (
+    <AnimatePresence>
+      {open && content && (
+        <motion.div
+          className="fixed inset-0 z-modal flex items-center justify-center"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          {/* Overlay */}
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+
+          {/* Dialog */}
+          <motion.div
+            ref={focusTrapRef}
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="wallet-error-title"
+            aria-describedby="wallet-error-description"
+            className="relative z-overlay w-full max-w-sm rounded-2xl border border-red-500/30 bg-gray-900/95 p-6 shadow-2xl"
+            initial={{ scale: 0.92, opacity: 0, y: 20 }}
+            animate={{ scale: 1, opacity: 1, y: 0 }}
+            exit={{ scale: 0.92, opacity: 0, y: 20 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+          >
+            {/* Close button */}
+            <button
+              onClick={onClose}
+              aria-label="Close error modal"
+              className="absolute right-4 top-4 rounded-full p-1 text-gray-400 hover:text-white hover:bg-white/10 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <X size={18} />
+            </button>
+
+            {/* Icon + Title */}
+            <div className="flex items-start gap-3 mb-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-500/15 border border-red-500/30">
+                <AlertTriangle
+                  size={20}
+                  className="text-red-400"
+                  aria-hidden="true"
+                />
+              </div>
+              <div>
+                <h2
+                  id="wallet-error-title"
+                  className="text-base font-semibold text-white"
+                >
+                  {content.title}
+                </h2>
+                <p
+                  id="wallet-error-description"
+                  className="mt-0.5 text-sm text-gray-400"
+                >
+                  {content.description}
+                </p>
+              </div>
+            </div>
+
+            {/* Recovery steps */}
+            <div className="mb-5 rounded-xl border border-white/10 bg-white/5 p-4">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                Recovery steps
+              </p>
+              <ol className="space-y-2">
+                {content.steps.map((step, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-gray-300">
+                    <CheckCircle2
+                      size={14}
+                      className="mt-0.5 shrink-0 text-blue-400"
+                      aria-hidden="true"
+                    />
+                    {step}
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              {reason === "not_found" ? (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onClose}
+                    className="text-gray-400 hover:text-white"
+                  >
+                    Dismiss
+                  </Button>
+                  <Button
+                    size="sm"
+                    data-autofocus="true"
+                    onClick={() => {
+                      window.open(
+                        "https://www.freighter.app",
+                        "_blank",
+                        "noopener,noreferrer"
+                      );
+                    }}
+                    className="gap-2"
+                  >
+                    <ExternalLink size={14} aria-hidden="true" />
+                    Install Freighter
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onClose}
+                    className="text-gray-400 hover:text-white"
+                  >
+                    Dismiss
+                  </Button>
+                  <Button
+                    size="sm"
+                    data-autofocus="true"
+                    onClick={() => {
+                      onClose();
+                      onRetry();
+                    }}
+                    className="gap-2"
+                  >
+                    <RefreshCw size={14} aria-hidden="true" />
+                    Retry Connection
+                  </Button>
+                </>
+              )}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/WalletDropdown.tsx
+++ b/components/WalletDropdown.tsx
@@ -2,14 +2,18 @@
 
 import { useRef, useState, useEffect, useCallback } from "react";
 import { useWallet } from "@/hooks/useWallet";
+import { usePortfolio } from "@/hooks/usePortfolio";
 import { Button } from "@/components/ui/button";
-import { Check, Copy, LogOut, ChevronDown } from "lucide-react";
+import { Check, Copy, LogOut, ChevronDown, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export function WalletDropdown() {
   const { publicKey, disconnect } = useWallet();
+  const { refetch } = usePortfolio();
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [refreshed, setRefreshed] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   const truncated = publicKey
@@ -22,6 +26,19 @@ export function WalletDropdown() {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }, [publicKey]);
+
+  const handleRefresh = useCallback(async () => {
+    if (isRefreshing) return;
+    setIsRefreshing(true);
+    setRefreshed(false);
+    try {
+      await refetch();
+      setRefreshed(true);
+      setTimeout(() => setRefreshed(false), 2500);
+    } finally {
+      setIsRefreshing(false);
+    }
+  }, [isRefreshing, refetch]);
 
   // Close on outside click
   useEffect(() => {
@@ -91,6 +108,40 @@ export function WalletDropdown() {
           </p>
 
           <hr className="border-border" />
+
+          {/* Refresh balance */}
+          <button
+            role="menuitem"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            aria-label={
+              isRefreshing
+                ? "Refreshing wallet balance…"
+                : refreshed
+                ? "Balance refreshed"
+                : "Refresh wallet balance"
+            }
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {refreshed ? (
+              <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+            ) : (
+              <RefreshCw
+                className={cn(
+                  "h-4 w-4",
+                  isRefreshing && "animate-spin text-blue-400"
+                )}
+                aria-hidden="true"
+              />
+            )}
+            <span aria-live="polite">
+              {isRefreshing
+                ? "Refreshing…"
+                : refreshed
+                ? "Balance updated"
+                : "Refresh balance"}
+            </span>
+          </button>
 
           {/* Copy */}
           <button

--- a/components/WalletSelectionModal.tsx
+++ b/components/WalletSelectionModal.tsx
@@ -6,6 +6,7 @@ import { X, Wallet, Loader2, ExternalLink, CheckCircle2, AlertCircle } from "luc
 import { isConnected } from "@stellar/freighter-api";
 import { useWallet } from "@/hooks/useWallet";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { WalletConnectErrorModal } from "@/components/WalletConnectErrorModal";
 
 interface WalletSelectionModalProps {
   open: boolean;
@@ -32,7 +33,7 @@ const WALLET_OPTIONS: WalletOption[] = [
 type DetectionState = "idle" | "detecting" | "detected" | "not-found";
 
 export function WalletSelectionModal({ open, onClose }: WalletSelectionModalProps) {
-  const { connect, isConnecting } = useWallet();
+  const { connect, isConnecting, connectError, clearConnectError } = useWallet();
   const [selectedWallet, setSelectedWallet] = useState<string | null>(null);
   const [detection, setDetection] = useState<Record<string, DetectionState>>({
     freighter: "idle",
@@ -88,11 +89,35 @@ export function WalletSelectionModal({ open, onClose }: WalletSelectionModalProp
 
     setSelectedWallet(wallet.id);
     await connect();
-    onClose();
+    // connect() sets connectError on failure; on success connectError stays null.
+    // The WalletConnectErrorModal below reacts to connectError automatically.
+    // We close the selection modal only when there is no error — checked via
+    // the store value after the async call settles.
   }
 
+  function handleErrorModalClose() {
+    clearConnectError();
+    setSelectedWallet(null);
+  }
+
+  function handleRetryFromError() {
+    clearConnectError();
+    setSelectedWallet(null);
+    // Re-open the selection modal (it is still mounted; just clear error state)
+  }
+
+  // Close selection modal on successful connection
+  useEffect(() => {
+    if (!isConnecting && !connectError && selectedWallet) {
+      // connect() finished without error — wallet connected successfully
+      onClose();
+      setSelectedWallet(null);
+    }
+  }, [isConnecting, connectError, selectedWallet, onClose]);
+
   return (
-    <AnimatePresence>
+    <>
+      <AnimatePresence>
       {open && (
         <motion.div
           className="fixed inset-0 z-modal flex items-center justify-center"
@@ -212,6 +237,15 @@ export function WalletSelectionModal({ open, onClose }: WalletSelectionModalProp
         </motion.div>
       )}
     </AnimatePresence>
+
+      {/* Wallet connect error modal — shown when connection fails */}
+      <WalletConnectErrorModal
+        open={!!connectError}
+        reason={connectError}
+        onClose={handleErrorModalClose}
+        onRetry={handleRetryFromError}
+      />
+    </>
   );
 }
 

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -12,6 +12,7 @@ import { NETWORK_PASSPHRASE } from "@/lib/stellar";
 import { walletToast } from "@/lib/walletToast";
 import { traceWorker } from "@/src/tracing/worker-tracing.service";
 import analyticsService from "@/services/analytics";
+import type { WalletConnectErrorReason } from "@/components/WalletConnectErrorModal";
 
 function isUserRejection(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -36,13 +37,20 @@ export function useWallet() {
   } = useWalletStore();
   const [isConnecting, setIsConnecting] = useState(false);
   const [isSigning, setIsSigning] = useState(false);
+  const [connectError, setConnectError] = useState<WalletConnectErrorReason>(null);
+
+  function clearConnectError() {
+    setConnectError(null);
+  }
 
   async function connect() {
     try {
       setIsConnecting(true);
+      setConnectError(null);
       const connectedResponse = await isConnected();
       if (!connectedResponse?.isConnected) {
         walletToast.notFound();
+        setConnectError("not_found");
         analyticsService.track('wallet_connect_failed', {
           wallet_type: 'freighter',
           reason: 'not_found',
@@ -70,6 +78,7 @@ export function useWallet() {
         });
       } else {
         walletToast.connectError();
+        setConnectError("error");
         console.error(err);
         analyticsService.track('wallet_connect_failed', {
           wallet_type: 'freighter',
@@ -119,5 +128,7 @@ export function useWallet() {
     sign,
     isConnecting,
     isSigning,
+    connectError,
+    clearConnectError,
   };
 }


### PR DESCRIPTION
Issue #116 - Wallet Connect Error Modal with Retry:
- Add WalletConnectErrorModal component (alertdialog, animated, accessible)
- Two error reasons: 'not_found' (Freighter missing) and 'error' (unexpected failure)
- 'not_found' surfaces an Install Freighter CTA; 'error' surfaces a Retry button
- Retry re-opens the WalletSelectionModal without a full page reload
- Modal uses focus trap (useFocusTrap), ESC-to-close, and overlay click-to-close
- Partial connection state preserved — wallet store is not cleared on error


Issue #131 - Wallet Balance Refresh Button:
- Add explicit Refresh balance button inside WalletDropdown menu
- Calls usePortfolio().refetch() — no full page reload required
- Shows spinning RefreshCw icon with 'Refreshing...' label during fetch
- Shows green Check icon with 'Balance updated' confirmation for 2.5s after success
- Button is disabled while refreshing to prevent duplicate requests


Supporting changes:
- useWallet hook now exposes connectError (WalletConnectErrorReason) and clearConnectError()
- Add .eslintrc.json (next/core-web-vitals) so next lint runs non-interactively

Closes #116
Closes #131