### PR TITLE
feat: add empty state variants and signal card expansion animation

### DIFF
--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -5,12 +5,14 @@ import {
   motion,
   useMotionValue,
   useTransform,
+  useReducedMotion,
   AnimatePresence,
   type PanInfo,
 } from "framer-motion";
 import {
   Bookmark,
   Check,
+  ChevronDown,
   Minus,
   Share2,
   TrendingDown,
@@ -101,6 +103,8 @@ export function SignalCard({
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copiedFeedback, setCopiedFeedback] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [detailsExpanded, setDetailsExpanded] = useState(false);
+  const shouldReduceMotion = useReducedMotion();
   const { isDemoMode } = useDemoModeStore();
   const fmt = usePriceFormat();
   const executingRef = useRef(false);
@@ -434,8 +438,49 @@ export function SignalCard({
               <MiniChart data={roiHistory.map((p) => p.value)} className="flex-1" />
             </div>
 
-            <p className="text-sm text-muted-foreground leading-relaxed">{analysis}</p>
+            {/* ── Issue #102: Expandable detail section with smooth animation ── */}
+            <button
+              type="button"
+              onClick={() => setDetailsExpanded((prev) => !prev)}
+              aria-expanded={detailsExpanded}
+              aria-controls={`signal-details-${signalId}`}
+              className="flex w-full items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-medium text-foreground-muted transition-colors hover:border-white/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+            >
+              <span>{detailsExpanded ? "Hide details" : "Show details"}</span>
+              <motion.span
+                animate={{ rotate: detailsExpanded ? 180 : 0 }}
+                transition={
+                  shouldReduceMotion
+                    ? { duration: 0 }
+                    : { duration: 0.2, ease: "easeInOut" }
+                }
+                aria-hidden="true"
+              >
+                <ChevronDown size={14} />
+              </motion.span>
+            </button>
 
+            <AnimatePresence initial={false}>
+              {detailsExpanded && (
+                <motion.div
+                  id={`signal-details-${signalId}`}
+                  key="signal-details"
+                  initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, height: 0 }}
+                  animate={shouldReduceMotion ? { opacity: 1 } : { opacity: 1, height: "auto" }}
+                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                  transition={
+                    shouldReduceMotion
+                      ? { duration: 0 }
+                      : { duration: 0.28, ease: [0.4, 0, 0.2, 1] }
+                  }
+                  style={{ overflow: "hidden" }}
+                >
+                  <div className="flex flex-col gap-3 pt-1">
+                    <p className="text-sm text-muted-foreground leading-relaxed">{analysis}</p>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
             {isPremium && !hasAccess && (
               <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2.5 text-sm">
                 <p className="font-medium text-accent-warning">Premium signal locked</p>

--- a/components/SignalEmptyState.tsx
+++ b/components/SignalEmptyState.tsx
@@ -1,42 +1,100 @@
 "use client";
 
-import { RadioTower, RefreshCw, Users } from "lucide-react";
+import { motion } from "framer-motion";
+import { BookOpen, RadioTower, RefreshCw, SearchX, Users } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
+type EmptyStateVariant = "no-signals" | "no-results";
+
 interface SignalEmptyStateProps {
+  /** Controls which copy and icon are shown.
+   *  - "no-signals"  — initial load / no signals published yet (default)
+   *  - "no-results"  — active filters returned zero matches
+   */
+  variant?: EmptyStateVariant;
   onRefresh: () => void;
 }
 
-export function SignalEmptyState({ onRefresh }: SignalEmptyStateProps) {
+const VARIANTS: Record<
+  EmptyStateVariant,
+  {
+    Icon: React.ElementType;
+    heading: string;
+    body: string;
+    ariaLabel: string;
+  }
+> = {
+  "no-signals": {
+    Icon: RadioTower,
+    heading: "No signals available right now",
+    body: "New signals appear as providers publish them. Follow providers to get notified first.",
+    ariaLabel: "No signals available",
+  },
+  "no-results": {
+    Icon: SearchX,
+    heading: "No signals match your filters",
+    body: "Try adjusting or clearing your filters to see more signals.",
+    ariaLabel: "No signals match the current filters",
+  },
+};
+
+export function SignalEmptyState({
+  variant = "no-signals",
+  onRefresh,
+}: SignalEmptyStateProps) {
+  const { Icon, heading, body, ariaLabel } = VARIANTS[variant];
+
   return (
-    <div className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-white/10 bg-slate-900/60 px-6 py-16 text-center">
+    <motion.div
+      role="status"
+      aria-label={ariaLabel}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+      className="flex flex-col items-center justify-center gap-6 rounded-3xl border border-white/10 bg-slate-900/60 px-6 py-16 text-center"
+    >
       {/* Icon */}
-      <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-slate-800/80">
-        <RadioTower className="h-8 w-8 text-sky-400/70" aria-hidden="true" />
+      <div
+        className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-slate-800/80"
+        aria-hidden="true"
+      >
+        <Icon className="h-8 w-8 text-sky-400/70" />
       </div>
 
       {/* Copy */}
       <div className="max-w-xs">
-        <p className="text-base font-semibold text-white">No signals available right now</p>
-        <p className="mt-1.5 text-sm text-foreground-muted">
-          New signals appear as providers publish them. Follow providers to get notified first.
-        </p>
+        <p className="text-base font-semibold text-white">{heading}</p>
+        <p className="mt-1.5 text-sm text-foreground-muted">{body}</p>
       </div>
 
       {/* CTAs */}
       <div className="flex flex-wrap items-center justify-center gap-3">
         <Button size="sm" variant="outline" onClick={onRefresh} className="gap-2">
           <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
-          Refresh
+          {variant === "no-results" ? "Clear & Refresh" : "Refresh"}
         </Button>
-        <Button size="sm" asChild className="gap-2">
-          <Link href="/providers">
-            <Users className="h-3.5 w-3.5" aria-hidden="true" />
-            Follow Providers
-          </Link>
+
+        {variant === "no-signals" && (
+          <Button size="sm" asChild className="gap-2">
+            <Link href="/providers">
+              <Users className="h-3.5 w-3.5" aria-hidden="true" />
+              Follow Providers
+            </Link>
+          </Button>
+        )}
+
+        <Button size="sm" variant="outline" asChild className="gap-2">
+          <a
+            href="https://docs.stellarswipe.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <BookOpen className="h-3.5 w-3.5" aria-hidden="true" />
+            Browse Docs
+          </a>
         </Button>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/components/signal/SignalFeed.tsx
+++ b/components/signal/SignalFeed.tsx
@@ -275,7 +275,18 @@ export function SignalFeed() {
         )}
 
         {!isLoading && !isError && signals.length === 0 && (
-          <SignalEmptyState onRefresh={() => refetch()} />
+          <SignalEmptyState
+            variant={
+              direction !== "ALL" ||
+              asset.trim() !== "" ||
+              provider.trim() !== "" ||
+              bookmarkedOnly ||
+              providerSearch.trim() !== ""
+                ? "no-results"
+                : "no-signals"
+            }
+            onRefresh={() => refetch()}
+          />
         )}
 
         {/* #98: skeleton while loading — consistent loading state */}


### PR DESCRIPTION
this PR 

Closes #102 
Closes #114 

Issue #114 - Signal Feed Placeholder UI for Empty States:
- Enhanced SignalEmptyState with a 'variant' prop ('no-signals' | 'no-results')
- 'no-signals' variant: shown on initial load when no signals are published yet
- 'no-results' variant: shown when active filters return zero matches (SearchX icon)
- Added fade-in entrance animation via framer-motion for a polished UX
- Added 'Browse Docs' CTA button alongside Refresh and Follow Providers actions



Issue #102 - Signal Card Expansion Animation:
- Added collapsible 'Show details / Hide details' section to SignalCard
- Expansion/collapse uses AnimatePresence + height animation (framer-motion)
- ChevronDown icon rotates 180deg on expand, 0deg on collapse
- Full prefers-reduced-motion support via useReducedMotion() hook
- When motion is reduced: instant show/hide with no height or rotation animation
- Animations use cubic-bezier easing for smooth, performant mobile transitions
