### PR TITLE
feat: add provider tags and status badges to signal cards

### DIFF
--- a/components/signal/SignalFeed.tsx
+++ b/components/signal/SignalFeed.tsx
@@ -344,7 +344,7 @@ export function SignalFeed() {
               <article
                 key={signal.id}
                 tabIndex={0}
-                aria-label={`${signal.ticker} ${signal.action} signal, ${signal.confidence}% confidence${isExpired ? ", expired" : ""}. Use arrow keys to navigate between signals.`}
+                aria-label={`${signal.ticker} ${signal.action} signal, ${signal.confidence}% confidence${signal.provider ? `, provider ${signal.provider}` : ""}${signal.status ? `, status ${signal.status}` : ""}${isExpired ? ", expired" : ""}. Use arrow keys to navigate between signals.`}
                 className="rounded-3xl border border-white/10 bg-slate-950/90 p-4 shadow-sm shadow-slate-950/20 transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 sm:p-6"
               >
                 {/* Expired banner — shown above content, clearly visible */}
@@ -368,6 +368,30 @@ export function SignalFeed() {
                       <h3 className="mt-2 text-base font-semibold tracking-tight text-white sm:text-xl">
                         {signal.ticker} • {signal.action}
                       </h3>
+                      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                        {signal.provider && (
+                          <span
+                            className="inline-flex items-center rounded-md bg-sky-500/10 px-2 py-0.5 text-[11px] font-medium text-sky-300 ring-1 ring-inset ring-sky-500/20"
+                            aria-label={`Provider: ${signal.provider}`}
+                          >
+                            {signal.provider}
+                          </span>
+                        )}
+                        {signal.status && (
+                          <span
+                            className={`inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium ring-1 ring-inset ${
+                              signal.status === "Active"
+                                ? "bg-emerald-500/10 text-emerald-300 ring-emerald-500/20"
+                                : signal.status === "Waiting"
+                                ? "bg-amber-500/10 text-amber-300 ring-amber-500/20"
+                                : "bg-slate-500/10 text-slate-400 ring-slate-500/20"
+                            }`}
+                            aria-label={`Status: ${signal.status}`}
+                          >
+                            {signal.status}
+                          </span>
+                        )}
+                      </div>
                     </div>
                     {/* #101: confidence badge with aria-label */}
                     <div

--- a/lib/signals.ts
+++ b/lib/signals.ts
@@ -1,4 +1,5 @@
 export type SignalAction = "BUY" | "SELL" | "HOLD";
+export type SignalStatus = "Active" | "Waiting" | "Closed";
 
 export interface Signal {
   id: string;
@@ -9,6 +10,10 @@ export interface Signal {
   timestamp: string;
   /** ISO timestamp after which the signal is considered expired / no longer actionable */
   expiresAt?: string;
+  /** Name of the signal provider */
+  provider?: string;
+  /** Current execution state of the signal */
+  status?: SignalStatus;
 }
 
 export interface SignalFeedPage {
@@ -22,6 +27,11 @@ export interface SignalFeedPage {
 
 const signalTickers = ["XLM", "BTC", "ETH", "USDC", "ADA", "SOL", "DOT", "MATIC", "ATOM", "LUNA"];
 const signalActions: SignalAction[] = ["BUY", "SELL", "HOLD"];
+const signalStatuses: SignalStatus[] = ["Active", "Waiting", "Closed"];
+const signalProviders = [
+  "AlphaWave", "OrionSignals", "NebulaAI", "QuantPulse", "StellarEdge",
+  "NovaTrade", "ZenithFX", "PolarSignals", "ApexQuant", "CosmicAlpha",
+];
 const signalDetails = [
   "Momentum building after a strong volume breakout.",
   "Price action suggests a reversal setup near support.",
@@ -58,6 +68,8 @@ export function buildSignalPage(page = 1, pageSize = 10): SignalFeedPage {
       details,
       timestamp,
       expiresAt,
+      provider: signalProviders[index % signalProviders.length],
+      status: signalStatuses[index % signalStatuses.length],
     };
   });
 


### PR DESCRIPTION
## Summary

Closes #197

Adds provider name tags and status badges to signal cards in the feed so users can quickly identify signal source and current execution state.

## Changes

- Added `SignalStatus` type (`Active` | `Waiting` | `Closed`) and `provider` / `status` fields to the `Signal` interface in `lib/signals.ts`
- `buildSignalPage` now assigns mock provider names and statuses to all signals
- `SignalFeed` renders a **provider tag** (sky ring) and a **status badge** below the signal title:
  - `Active` → emerald
  - `Waiting` → amber
  - `Closed` → slate
- Badges use `flex-wrap` so layout stays clean on narrow screens
- Each badge has an `aria-label` for screen reader accessibility

## Acceptance Criteria

- [x] Signal cards display provider name badges
- [x] Signal cards show status badges (Active, Waiting, Closed)
- [x] Badges use distinct colors and accessible contrast
- [x] Status badges update based on signal metadata
- [x] Layout remains clean on narrow screens