### PR TITLE
Gate React Query Devtools to local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Set environment variables (.env.local):
 Run dev server:
   npm run dev
 
+## React Query Devtools
+
+Local development builds automatically show the React Query Devtools toggle for inspecting query cache state, freshness, and refetch behavior. The panel is mounted inside the app's existing `QueryClientProvider`, so hooks such as `useSignals` and `usePortfolio` appear in the same cache the app uses.
+
+The devtools are loaded only when `NODE_ENV=development`; production builds render no devtools panel and do not require manual toggling.
+
 ## Worker Tracing
 
 Asynchronous worker execution paths are instrumented via `src/tracing/worker-tracing.service.ts`.
@@ -81,4 +87,3 @@ In development (`NODE_ENV=development`) spans are logged to `console.debug`. Rep
 ```bash
 npm test
 ```
-

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/lib/queryClient";
 import { ToastProvider } from "@/components/ui/toast";
+import { ReactQueryDevtoolsPanel } from "@/components/ReactQueryDevtoolsPanel";
 import { initI18n } from "@/lib/i18n";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -16,7 +16,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       {children}
       <ToastProvider />
-      <ReactQueryDevtools initialIsOpen={false} />
+      <ReactQueryDevtoolsPanel />
     </QueryClientProvider>
   );
 }

--- a/components/ReactQueryDevtoolsPanel.tsx
+++ b/components/ReactQueryDevtoolsPanel.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const Devtools =
+  process.env.NODE_ENV === "development"
+    ? dynamic(
+        () =>
+          import("@tanstack/react-query-devtools").then(
+            (mod) => mod.ReactQueryDevtools
+          ),
+        { ssr: false }
+      )
+    : null;
+
+export function ReactQueryDevtoolsPanel() {
+  if (!Devtools) return null;
+
+  return <Devtools initialIsOpen={false} buttonPosition="bottom" />;
+}


### PR DESCRIPTION
## Summary



Moves React Query Devtools behind an explicit development-only dynamic boundary and documents how to use the panel locally.

## Changes

- Replaced the direct `@tanstack/react-query-devtools` import in `app/providers.tsx` with a small `ReactQueryDevtoolsPanel` component.
- Dynamically loads `ReactQueryDevtools` only when `NODE_ENV=development` and returns `null` otherwise.
- Keeps the panel mounted inside the existing `QueryClientProvider`, so it observes the same cache used by real hooks such as `useSignals`, `usePortfolio`, `useLeaderboard`, and `useProviderProfile`.
- Added README notes for local debugging and production behavior.

## Validation

Passed locally:

```sh
node - <<'NODE'
const fs = require('fs');
const providers = fs.readFileSync('app/providers.tsx', 'utf8');
const panel = fs.readFileSync('components/ReactQueryDevtoolsPanel.tsx', 'utf8');
if (/from\\s+["']@tanstack\\/react-query-devtools["']/.test(providers)) process.exit(1);
if (!panel.includes('process.env.NODE_ENV === "development"')) process.exit(2);
if (!panel.includes('dynamic(') || !panel.includes('@tanstack/react-query-devtools')) process.exit(3);
console.log('dev-only React Query Devtools boundary verified');
NODE

git diff --check
```

Production bundle check:

```sh
npm run build -- --no-lint
rg -n "ReactQueryDevtools|react-query-devtools|TanStack Query Devtools" .next/static .next/server
```

Because the current repository has pre-existing TypeScript errors, I temporarily enabled `typescript.ignoreBuildErrors` locally only to emit a production bundle for inspection, then reverted that local config before committing. The emitted production bundle contained no React Query Devtools strings.

Existing baseline checks still fail outside this change:

```sh
npm run lint
```

Fails on existing hook-order errors in `components/SignalCard.tsx` and an existing dependency warning in `components/SignalRecommendations.tsx`.

```sh
npm test -- --runInBand
```

Fails because the current Jest/ts-jest setup does not transform TSX JSX in two existing component test files.

```sh
npm run build -- --no-lint
```

Fails on an existing Framer Motion type error in `components/CTABanner.tsx` after lint is skipped.
