### PR TITLE
Add reduced motion support for non-essential animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Set environment variables (.env.local):
 Run dev server:
   npm run dev
 
+## Reduced Motion
+
+The app respects the system `prefers-reduced-motion` setting. When reduced motion is enabled, Framer Motion is configured globally with `reducedMotion="user"`, landing-page reveal animations render instantly, and page-transition placeholders keep their loading feedback visible without slide/pulse motion.
+
+To verify locally, open browser rendering tools or OS accessibility settings, enable reduced motion, then reload the app. The hero and scroll-reveal sections should appear without movement, and route-change placeholders should remain visible without animated transitions.
+
 ## Worker Tracing
 
 Asynchronous worker execution paths are instrumented via `src/tracing/worker-tracing.service.ts`.
@@ -81,4 +87,3 @@ In development (`NODE_ENV=development`) spans are logged to `console.debug`. Rep
 ```bash
 npm test
 ```
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,18 +10,20 @@ import { CTABanner } from "@/components/CTABanner";
 import { HowItWorks } from "@/components/HowItWorks";
 import { Footer } from "@/components/Footer";
 import { PageTransition } from "@/components/PageTransition";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 
 export default function Home() {
   const { publicKey, connected, connect, disconnect } = useWallet();
   const [tradeOpen, setTradeOpen] = useState(false);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   return (
     <PageTransition>
       <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 sm:gap-8 sm:p-8 bg-gray-950">
         <motion.div
-          initial={{ opacity: 0, y: -20 }}
+          initial={prefersReducedMotion ? false : { opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
+          transition={prefersReducedMotion ? { duration: 0 } : { duration: 0.5 }}
           className="relative text-center"
         >
           <h1 className="text-2xl font-bold tracking-tight text-white sm:text-3xl md:text-4xl">
@@ -33,9 +35,11 @@ export default function Home() {
         </motion.div>
 
         <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
+          initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.95 }}
           animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.2, duration: 0.4 }}
+          transition={
+            prefersReducedMotion ? { duration: 0 } : { delay: 0.2, duration: 0.4 }
+          }
           className="flex flex-col items-center gap-4"
         >
           {connected ? (

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { MotionConfig } from "framer-motion";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/lib/queryClient";
@@ -14,9 +15,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
-      <ToastProvider />
-      <ReactQueryDevtools initialIsOpen={false} />
+      <MotionConfig reducedMotion="user">
+        {children}
+        <ToastProvider />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </MotionConfig>
     </QueryClientProvider>
   );
 }

--- a/components/FeatureCards.tsx
+++ b/components/FeatureCards.tsx
@@ -64,7 +64,7 @@ export function FeatureCards() {
                 {...scrollProps}
                 className="group flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-900 p-6
                            transition-all duration-300 hover:border-sky-500/40 hover:shadow-lg hover:shadow-sky-900/20
-                           hover:-translate-y-1"
+                           hover:-translate-y-1 motion-reduce:transition-none motion-reduce:hover:transform-none"
               >
                 <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-sky-500/10 border border-sky-500/20">
                   <Icon size={22} className="text-sky-400" aria-hidden />

--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { ReactNode } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 
 interface PageTransitionProps {
   children: ReactNode;
@@ -14,6 +15,12 @@ const variants = {
 };
 
 export function PageTransition({ children }: PageTransitionProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  if (prefersReducedMotion) {
+    return <>{children}</>;
+  }
+
   return (
     <motion.div
       initial="hidden"

--- a/components/PageTransitionPlaceholder.tsx
+++ b/components/PageTransitionPlaceholder.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { usePageTransitionStore } from "@/store/usePageTransitionStore";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { PageTransitionSkeleton } from "./PageTransitionSkeleton";
 
 /**
@@ -45,6 +46,7 @@ export function PageTransitionPlaceholder({
   minShowDuration = 300,
 }: PageTransitionPlaceholderProps) {
   const pathname = usePathname();
+  const prefersReducedMotion = usePrefersReducedMotion();
   const { isTransitioning, startTransition, completeTransition } =
     usePageTransitionStore();
 
@@ -55,6 +57,8 @@ export function PageTransitionPlaceholder({
   >("feed");
   const showTimerRef = useRef<NodeJS.Timeout | null>(null);
   const minDurationTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const effectiveShowDelay = prefersReducedMotion ? 0 : showDelay;
+  const effectiveMinShowDuration = prefersReducedMotion ? 0 : minShowDuration;
 
   // Determine skeleton variant based on route
   const getSkeletonVariant = (
@@ -85,14 +89,14 @@ export function PageTransitionPlaceholder({
       // Ensure minimum display duration for visibility
       minDurationTimerRef.current = setTimeout(() => {
         setVisiblePlaceholder(false);
-      }, minShowDuration);
-    }, showDelay);
+      }, effectiveMinShowDuration);
+    }, effectiveShowDelay);
 
     return () => {
       if (showTimerRef.current) clearTimeout(showTimerRef.current);
       if (minDurationTimerRef.current) clearTimeout(minDurationTimerRef.current);
     };
-  }, [pathname, showDelay, minShowDuration, startTransition]);
+  }, [pathname, effectiveShowDelay, effectiveMinShowDuration, startTransition]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -107,13 +111,17 @@ export function PageTransitionPlaceholder({
       {(isTransitioning || visiblePlaceholder) && (
         <motion.div
           key="page-transition-placeholder"
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -12 }}
-          transition={{
-            duration: 0.25,
-            ease: "easeInOut",
-          }}
+          initial={prefersReducedMotion ? { opacity: 1 } : { opacity: 0, y: 12 }}
+          animate={prefersReducedMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -12 }}
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : {
+                  duration: 0.25,
+                  ease: "easeInOut",
+                }
+          }
           className="fixed inset-0 top-14 z-loading bg-background pointer-events-none overflow-y-auto"
           aria-hidden="true"
           role="status"

--- a/components/PageTransitionSkeleton.tsx
+++ b/components/PageTransitionSkeleton.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+
 /**
  * PageTransitionSkeleton
  * ─────────────────────
@@ -16,6 +18,9 @@ interface PageTransitionSkeletonProps {
 export function PageTransitionSkeleton({
   variant = "feed",
 }: PageTransitionSkeletonProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const pulseClass = prefersReducedMotion ? "" : "animate-pulse";
+
   if (variant === "feed") {
     return (
       <div className="w-full space-y-3 md:space-y-4 px-3 md:px-0">
@@ -24,7 +29,7 @@ export function PageTransitionSkeleton({
           {[...Array(2)].map((_, i) => (
             <div
               key={i}
-              className="w-full rounded-xl border border-border bg-surface p-4 md:p-5 space-y-3 md:space-y-4 animate-pulse"
+              className={`w-full rounded-xl border border-border bg-surface p-4 md:p-5 space-y-3 md:space-y-4 ${pulseClass}`}
             >
               {/* Header */}
               <div className="flex items-center justify-between">
@@ -61,7 +66,7 @@ export function PageTransitionSkeleton({
     return (
       <div className="w-full space-y-4 md:space-y-6 px-3 md:px-0">
         {/* Header section */}
-        <div className="rounded-xl border border-border bg-surface p-4 md:p-6 space-y-4 animate-pulse">
+        <div className={`rounded-xl border border-border bg-surface p-4 md:p-6 space-y-4 ${pulseClass}`}>
           <div className="h-8 w-3/4 md:w-1/2 rounded bg-surface-high" />
           <div className="flex flex-col md:flex-row gap-3 md:gap-4">
             <div className="h-6 w-24 rounded bg-surface-high" />
@@ -73,7 +78,7 @@ export function PageTransitionSkeleton({
         {[...Array(2)].map((_, i) => (
           <div
             key={i}
-            className="rounded-xl border border-border bg-surface p-4 md:p-6 space-y-3 md:space-y-4 animate-pulse"
+            className={`rounded-xl border border-border bg-surface p-4 md:p-6 space-y-3 md:space-y-4 ${pulseClass}`}
           >
             <div className="h-6 w-32 rounded bg-surface-high" />
             <div className="space-y-2">
@@ -89,7 +94,7 @@ export function PageTransitionSkeleton({
 
   if (variant === "table") {
     return (
-      <div className="w-full rounded-xl border border-border bg-surface overflow-hidden animate-pulse">
+      <div className={`w-full rounded-xl border border-border bg-surface overflow-hidden ${pulseClass}`}>
         {/* Table header */}
         <div className="hidden md:flex items-center gap-4 px-4 md:px-6 py-4 border-b border-border bg-surface-high">
           {[...Array(4)].map((_, i) => (
@@ -132,7 +137,7 @@ export function PageTransitionSkeleton({
           {[...Array(6)].map((_, i) => (
             <div
               key={i}
-              className="rounded-xl border border-border bg-surface p-4 space-y-3 animate-pulse"
+              className={`rounded-xl border border-border bg-surface p-4 space-y-3 ${pulseClass}`}
             >
               <div className="h-40 w-full rounded-lg bg-surface-high" />
               <div className="space-y-2">

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { useReducedMotion } from "framer-motion";
+
+export function usePrefersReducedMotion() {
+  return useReducedMotion() ?? false;
+}

--- a/hooks/useScrollAnimation.ts
+++ b/hooks/useScrollAnimation.ts
@@ -1,28 +1,37 @@
 "use client";
 
-import { useReducedMotion } from "framer-motion";
+import type { Variants } from "framer-motion";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 
-export const fadeUpVariants = {
+export const fadeUpVariants: Variants = {
   hidden: { opacity: 0, y: 24 },
   visible: (i = 0) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: i * 0.12, duration: 0.5, ease: "easeOut" },
+    transition: { delay: i * 0.12, duration: 0.5, ease: "easeOut" as const },
   }),
 };
 
-export const fadeInVariants = {
+export const fadeInVariants: Variants = {
   hidden: { opacity: 0 },
   visible: (i = 0) => ({
     opacity: 1,
-    transition: { delay: i * 0.1, duration: 0.4, ease: "easeOut" },
+    transition: { delay: i * 0.1, duration: 0.4, ease: "easeOut" as const },
   }),
 };
 
 export function useScrollViewport() {
-  const reduced = useReducedMotion();
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  if (prefersReducedMotion) {
+    return {
+      initial: false as const,
+      animate: "visible" as const,
+    };
+  }
+
   return {
-    initial: reduced ? "visible" : "hidden",
+    initial: "hidden" as const,
     whileInView: "visible" as const,
     viewport: { once: true, amount: 0.2 },
   };


### PR DESCRIPTION
## Summary



Adds shared reduced-motion support so users with `prefers-reduced-motion: reduce` get instant/simple landing and page-transition behavior while loading and status feedback remains visible.

## Changes

- Added `usePrefersReducedMotion()` as the shared hook for the system reduced-motion preference.
- Wrapped the app in Framer Motion's `MotionConfig reducedMotion="user"` so descendant motion components inherit the user preference.
- Updated landing-page hero and scroll-reveal helpers to render instantly when reduced motion is preferred.
- Updated `PageTransition` to skip non-essential route transition motion for reduced-motion users.
- Updated `PageTransitionPlaceholder` to keep loading feedback visible while removing slide/pulse animation timing under reduced motion.
- Removed pulse animation from transition skeleton placeholders when reduced motion is preferred.
- Added README verification notes for toggling reduced motion locally.
- Tightened shared scroll animation variant typing while touching the animation helper.

## Validation

Passed locally:

```sh
node - <<'NODE'
const fs = require('fs');
const required = [
  ['hooks/usePrefersReducedMotion.ts', /usePrefersReducedMotion/],
  ['components/PageTransition.tsx', /usePrefersReducedMotion/],
  ['components/PageTransitionPlaceholder.tsx', /usePrefersReducedMotion/],
  ['components/PageTransitionSkeleton.tsx', /usePrefersReducedMotion/],
  ['hooks/useScrollAnimation.ts', /usePrefersReducedMotion/],
  ['app/page.tsx', /usePrefersReducedMotion/],
  ['app/providers.tsx', /MotionConfig[\\s\\S]*reducedMotion="user"/],
  ['README.md', /Reduced Motion[\\s\\S]*prefers-reduced-motion/],
];
for (const [file, pattern] of required) {
  if (!fs.existsSync(file)) throw new Error(`missing ${file}`);
  const text = fs.readFileSync(file, 'utf8');
  if (!pattern.test(text)) throw new Error(`${file} does not match ${pattern}`);
}
console.log('reduced-motion integration present');
NODE

git diff --check
```

Also reran broader checks. They still fail on existing baseline issues outside this change:

```sh
npm run lint
```

Fails on existing hook-order errors in `components/SignalCard.tsx` and an existing dependency warning in `components/SignalRecommendations.tsx`.

```sh
npm test -- --runInBand
```

Fails because the current Jest/ts-jest setup does not transform TSX JSX in two existing component test files.

```sh
npm run build -- --no-lint
```

Now gets past the touched animation variant helpers, then fails on an existing `components/SignalCard.tsx` type error (`setActionAnnouncement` is not defined).
