### PR TITLE
Prevent initial theme flash before hydration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { PageTransitionPlaceholder } from "@/components/PageTransitionPlaceholde
 import { TradeStatusBanner } from "@/components/TradeStatusBanner";
 import { DevPerfOverlay } from "@/components/DevPerfOverlay";
 import { ScrollRestoration } from "@/components/ScrollRestoration";
+import { themeInitScript } from "@/lib/theme";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -31,10 +32,10 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Apply persisted theme before first paint to avoid flash */}
+        {/* Apply persisted theme before first paint to avoid flash. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var item=localStorage.getItem('stellar-theme');var theme=item?JSON.parse(item).state?.theme:null; if(!theme){theme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';} document.documentElement.classList.remove('light','dark'); document.documentElement.classList.add(theme);}catch(e){}})();`,
+            __html: themeInitScript,
           }}
         />
       </head>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -2,6 +2,7 @@
 
 import { Moon, Sun } from "lucide-react";
 import { useThemeStore } from "@/store/useThemeStore";
+import { applyThemeToDocument } from "@/lib/theme";
 import { useEffect } from "react";
 
 /**
@@ -13,14 +14,7 @@ export function ThemeToggle() {
 
   // Sync theme class on <html> whenever it changes
   useEffect(() => {
-    const root = document.documentElement;
-    if (theme === "light") {
-      root.classList.remove("dark");
-      root.classList.add("light");
-    } else {
-      root.classList.remove("light");
-      root.classList.add("dark");
-    }
+    applyThemeToDocument(theme);
   }, [theme]);
 
   return (

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,97 @@
+export type Theme = "dark" | "light";
+
+export const THEME_STORAGE_KEY = "stellar-theme";
+export const DEFAULT_THEME: Theme = "dark";
+
+declare global {
+  interface Window {
+    __STELLAR_THEME__?: Theme;
+  }
+}
+
+export function isTheme(value: unknown): value is Theme {
+  return value === "dark" || value === "light";
+}
+
+function getSystemTheme(): Theme {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
+
+  return "light";
+}
+
+function getStoredTheme(): Theme | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const item = window.localStorage.getItem(THEME_STORAGE_KEY);
+    const storedTheme = item ? JSON.parse(item).state?.theme : null;
+    return isTheme(storedTheme) ? storedTheme : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return DEFAULT_THEME;
+  }
+
+  if (isTheme(window.__STELLAR_THEME__)) {
+    return window.__STELLAR_THEME__;
+  }
+
+  return getStoredTheme() ?? getSystemTheme();
+}
+
+export function applyThemeToDocument(
+  theme: Theme,
+  root = document.documentElement
+) {
+  root.classList.remove("light", "dark");
+  root.classList.add(theme);
+  root.style.colorScheme = theme;
+  root.dataset.theme = theme;
+
+  if (typeof window !== "undefined") {
+    window.__STELLAR_THEME__ = theme;
+  }
+}
+
+export const themeInitScript = `
+(function() {
+  var theme = "${DEFAULT_THEME}";
+  try {
+    var item = localStorage.getItem("${THEME_STORAGE_KEY}");
+    var parsed = item ? JSON.parse(item) : null;
+    var storedTheme = parsed && parsed.state && parsed.state.theme;
+    if (storedTheme === "dark" || storedTheme === "light") {
+      theme = storedTheme;
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      theme = "dark";
+    } else {
+      theme = "light";
+    }
+  } catch (error) {
+    try {
+      theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    } catch (systemError) {
+      theme = "${DEFAULT_THEME}";
+    }
+  }
+
+  var root = document.documentElement;
+  root.classList.remove("light", "dark");
+  root.classList.add(theme);
+  root.style.colorScheme = theme;
+  root.dataset.theme = theme;
+  window.__STELLAR_THEME__ = theme;
+})();
+`;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:theme-first-paint": "node scripts/verify-theme-first-paint.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/scripts/verify-theme-first-paint.mjs
+++ b/scripts/verify-theme-first-paint.mjs
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+
+const read = (file) => fs.readFileSync(file, "utf8");
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const theme = read("lib/theme.ts");
+const layout = read("app/layout.tsx");
+const toggle = read("components/ThemeToggle.tsx");
+const store = read("store/useThemeStore.ts");
+
+assert(theme.includes("THEME_STORAGE_KEY"), "theme storage key is centralized");
+assert(theme.includes("themeInitScript"), "first-paint script is exported");
+assert(theme.includes("applyThemeToDocument"), "DOM theme application is shared");
+assert(theme.includes("getInitialTheme"), "client store can read first-paint theme");
+assert(
+  /classList\.remove\("light", "dark"\)/.test(theme),
+  "theme script removes stale theme classes"
+);
+assert(
+  /classList\.add\(theme\)/.test(theme),
+  "theme script applies the resolved theme class"
+);
+assert(
+  /style\.colorScheme = theme/.test(theme),
+  "theme script sets color-scheme before paint"
+);
+assert(
+  /dataset\.theme = theme/.test(theme),
+  "theme script exposes data-theme before paint"
+);
+assert(
+  /__STELLAR_THEME__/.test(theme),
+  "theme script exposes the resolved theme to hydration"
+);
+assert(
+  /storedTheme === "dark" \|\| storedTheme === "light"/.test(theme),
+  "theme script validates persisted theme values"
+);
+assert(
+  /matchMedia\("\(prefers-color-scheme: dark\)"\)/.test(theme),
+  "theme script falls back to system preference"
+);
+
+assert(
+  layout.includes("themeInitScript") &&
+    layout.includes('__html: themeInitScript'),
+  "layout uses the shared first-paint theme script"
+);
+assert(
+  layout.includes("suppressHydrationWarning"),
+  "html element suppresses expected theme-class hydration differences"
+);
+assert(
+  toggle.includes("applyThemeToDocument"),
+  "theme toggle reuses shared DOM theme application"
+);
+assert(
+  store.includes("getInitialTheme"),
+  "theme store initializes from the first-paint resolved theme"
+);
+
+console.log("first-paint theme guard verified");

--- a/store/useThemeStore.ts
+++ b/store/useThemeStore.ts
@@ -2,8 +2,7 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
-type Theme = "dark" | "light";
+import { getInitialTheme, type Theme } from "@/lib/theme";
 
 interface ThemeState {
   theme: Theme;
@@ -14,7 +13,7 @@ interface ThemeState {
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set, get) => ({
-      theme: "dark",
+      theme: getInitialTheme(),
       setTheme: (theme) => set({ theme }),
       toggle: () => set({ theme: get().theme === "dark" ? "light" : "dark" }),
     }),


### PR DESCRIPTION
## Summary


Reworks the first-paint theme guard so the persisted or system theme is resolved before visual paint, exposed to hydration, and reused by the client-side theme store and toggle.

## Changes

- Added `lib/theme.ts` with the centralized storage key, theme validation, first-paint script, hydration initial-theme resolver, and DOM theme application helper.
- Updated `app/layout.tsx` to use the shared `themeInitScript` in `<head>` instead of an inline one-off snippet.
- Updated `useThemeStore` to initialize from the first-paint resolved theme or the same localStorage/system fallback path.
- Updated `ThemeToggle` to reuse `applyThemeToDocument()`, keeping `<html>` class, `data-theme`, `color-scheme`, and the hydration hint in sync.
- Added `npm run verify:theme-first-paint` as a focused regression check for the first-paint theme contract.

## Validation

Passed locally:

```sh
npm run verify:theme-first-paint
npx tsc --noEmit --pretty false --skipLibCheck --jsx react-jsx --moduleResolution bundler --module esnext --target es2020 --lib es2020,dom lib/theme.ts
git diff --check
```

Also reran broader existing checks. They still fail on baseline issues outside this theme initialization change:

```sh
npm run lint
```

Fails on existing hook-order errors in `components/SignalCard.tsx` and an existing dependency warning in `components/SignalRecommendations.tsx`.

```sh
npm test -- --runInBand
```

Fails because the current Jest/ts-jest setup does not transform TSX JSX in two existing component test files.

```sh
npm run build -- --no-lint
```

Compiles with existing Stellar SDK/sodium warnings, then fails on an existing Framer Motion variant type error in `components/CTABanner.tsx`.

Manual Chrome/Safari visual reload verification is still recommended because I cannot honestly claim the cross-browser visual pass from this environment.
