### PR TITLE
Configure Renovate dependency update PRs

### DIFF
--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,25 @@
+# Dependency Updates
+
+This repository uses Renovate to open dependency update pull requests automatically.
+
+## Update Grouping
+
+Renovate groups routine patch and minor production dependency updates into a single `non-major dependency updates` pull request. Patch and minor development dependency updates are grouped separately as `dev dependency updates`.
+
+Major version upgrades are separated from routine updates and require approval from the Renovate dependency dashboard before Renovate opens the pull request. This keeps large framework changes, such as Next.js, React, Zustand, React Query, and testing-tool upgrades, visible for explicit review.
+
+## Security Updates
+
+Security-relevant updates receive the `security` label in addition to the default `dependencies` label. Review those first and avoid batching them with unrelated feature work.
+
+## CI Review Policy
+
+Renovate pull requests should go through the same checks as any other pull request in this repository. When CI workflows are present, keep dependency PRs blocked until the configured pull-request checks pass. If a dependency PR changes generated lockfile contents, review both `package.json` and `package-lock.json` before merging.
+
+## Maintainer Workflow
+
+1. Review the dependency dashboard for pending major updates.
+2. Approve only one risky major update at a time.
+3. Prioritize PRs labeled `security`.
+4. Merge routine grouped updates only after CI passes and the app still builds locally or in CI.
+5. Close or rebase stale dependency PRs instead of merging outdated lockfile changes.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:renovate-config": "node scripts/verify-renovate-config.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "automerge": false,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "separateMajorMinor": true,
+  "vulnerabilityAlerts": {
+    "labels": ["dependencies", "security"],
+    "dependencyDashboardApproval": false,
+    "automerge": false
+  },
+  "packageRules": [
+    {
+      "description": "Group routine production dependency updates",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "non-major dependency updates",
+      "labels": ["dependencies"]
+    },
+    {
+      "description": "Group routine development dependency updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev dependency updates",
+      "labels": ["dependencies", "dev-dependencies"]
+    },
+    {
+      "description": "Require explicit dashboard approval before major upgrades",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "labels": ["dependencies", "major"]
+    }
+  ]
+}

--- a/scripts/verify-renovate-config.mjs
+++ b/scripts/verify-renovate-config.mjs
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const config = JSON.parse(fs.readFileSync("renovate.json", "utf8"));
+const docs = fs.readFileSync("docs/dependency-updates.md", "utf8");
+
+assert(
+  Array.isArray(config.extends) &&
+    config.extends.includes("config:recommended"),
+  "Renovate extends the recommended baseline"
+);
+assert(config.dependencyDashboard === true, "dependency dashboard is enabled");
+assert(config.automerge === false, "dependency updates are not automerged");
+assert(
+  config.prConcurrentLimit > 0 && config.prHourlyLimit > 0,
+  "PR rate limits are configured"
+);
+assert(
+  Array.isArray(config.labels) && config.labels.includes("dependencies"),
+  "default dependency label is configured"
+);
+assert(
+  config.vulnerabilityAlerts &&
+    Array.isArray(config.vulnerabilityAlerts.labels) &&
+    config.vulnerabilityAlerts.labels.includes("security"),
+  "security updates receive a security label"
+);
+
+const packageRules = config.packageRules ?? [];
+const hasPatchMinorGroup = packageRules.some(
+  (rule) =>
+    rule.groupName === "non-major dependency updates" &&
+    rule.matchUpdateTypes?.includes("minor") &&
+    rule.matchUpdateTypes?.includes("patch")
+);
+const hasMajorSeparation = packageRules.some(
+  (rule) =>
+    rule.matchUpdateTypes?.includes("major") &&
+    rule.dependencyDashboardApproval === true
+);
+const hasDevGroup = packageRules.some(
+  (rule) =>
+    rule.groupName === "dev dependency updates" &&
+    rule.matchDepTypes?.includes("devDependencies")
+);
+
+assert(hasPatchMinorGroup, "patch/minor updates are grouped");
+assert(hasMajorSeparation, "major updates require dashboard approval");
+assert(hasDevGroup, "dev dependency updates are grouped separately");
+
+assert(
+  docs.includes("Renovate") &&
+    docs.includes("security") &&
+    docs.includes("major") &&
+    docs.includes("CI"),
+  "maintenance documentation covers Renovate, security, major updates, and CI"
+);
+
+console.log("Renovate dependency update policy verified");


### PR DESCRIPTION
## Summary

Adds Renovate configuration for automated dependency update pull requests, with grouped routine updates, separated major updates, and distinct security labeling.

## Changes

- Added `renovate.json` extending Renovate's recommended baseline.
- Groups non-major production dependency updates separately from non-major development dependency updates.
- Keeps major upgrades separate and requires dependency dashboard approval before PR creation.
- Labels security-relevant updates with `security` and keeps automerge disabled.
- Documents the dependency update review workflow in `docs/dependency-updates.md`.
- Adds `npm run verify:renovate-config` as a focused repository policy check for the Renovate configuration.

## Validation

Passed locally:

```sh
npm run verify:renovate-config
node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8')); JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('json ok')"
git diff --check
npx --yes --package renovate renovate-config-validator renovate.json
```

The official Renovate validator reported: `Config validated successfully`.

I did not rerun the app lint/test/build suite for this config-only change because this PR does not change runtime source code and the repository currently has known baseline lint/test/build failures documented in the other open PRs.
