### PR TITLE
Harden next/font loading configuration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,11 +11,15 @@ import { ScrollRestoration } from "@/components/ScrollRestoration";
 const inter = Inter({
   variable: "--font-sans",
   subsets: ["latin"],
+  display: "swap",
+  fallback: ["system-ui", "sans-serif"],
 });
 
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-mono",
   subsets: ["latin"],
+  display: "swap",
+  fallback: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
 });
 
 export const metadata: Metadata = {

--- a/docs/font-loading.md
+++ b/docs/font-loading.md
@@ -1,0 +1,38 @@
+# Font Loading Audit
+
+StellarSwipe loads its application fonts through `next/font/google` in `app/layout.tsx`.
+
+## Current Font Stack
+
+- `Inter` is the primary sans-serif UI font and is exposed as `--font-sans`.
+- `JetBrains_Mono` is the monospace font and is exposed as `--font-mono`.
+- Both fonts use `display: "swap"` so text remains visible while the webfont loads.
+- Both fonts declare explicit fallback stacks to keep metrics stable if a webfont is delayed or unavailable.
+
+The global body stack in `app/globals.css` remains:
+
+```css
+font-family: var(--font-sans), system-ui, sans-serif;
+```
+
+This preserves the system fallback path for browsers or locales where the primary webfont is not immediately available.
+
+## CLS And Lighthouse Review
+
+The previous implementation already used `next/font`, so this change is an audit and hardening pass rather than a migration away from plain CSS font imports. The explicit `display` and fallback settings reduce the chance that text is invisible or unstable during font download.
+
+For a production Lighthouse check, compare the landing page before and after this change and confirm the Cumulative Layout Shift (CLS) score is stable or improved. The local repository currently has unrelated baseline build failures, so the repeatable check for this PR is the static `npm run verify:font-loading` audit.
+
+## Locale Coverage
+
+The app currently imports the `latin` subset for both configured fonts. No non-Latin locale font is loaded in the current app shell. If a future locale requires non-Latin glyph coverage, add the relevant subset or a locale-specific font and update this audit before enabling that locale in production.
+
+## Visual Review Checklist
+
+When the app build baseline is healthy, verify these pages after a hard reload:
+
+1. Landing page
+2. Signal feed
+3. Portfolio or dashboard view
+
+Check that text is visible immediately, no large layout jump occurs when fonts finish loading, and monospace labels retain stable width.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:font-loading": "node scripts/verify-font-loading.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/scripts/verify-font-loading.mjs
+++ b/scripts/verify-font-loading.mjs
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const layout = fs.readFileSync("app/layout.tsx", "utf8");
+const css = fs.readFileSync("app/globals.css", "utf8");
+const docs = fs.readFileSync("docs/font-loading.md", "utf8");
+
+assert(
+  layout.includes('from "next/font/google"'),
+  "fonts are loaded through next/font/google"
+);
+assert(/Inter\(\{[\s\S]*display:\s*"swap"/.test(layout), "Inter uses font-display swap");
+assert(
+  /Inter\(\{[\s\S]*fallback:\s*\[[^\]]*"system-ui"[^\]]*"sans-serif"/.test(layout),
+  "Inter declares stable fallback fonts"
+);
+assert(
+  /JetBrains_Mono\(\{[\s\S]*display:\s*"swap"/.test(layout),
+  "JetBrains Mono uses font-display swap"
+);
+assert(
+  /JetBrains_Mono\(\{[\s\S]*fallback:\s*\[[^\]]*"ui-monospace"[^\]]*"monospace"/.test(layout),
+  "JetBrains Mono declares stable fallback fonts"
+);
+assert(
+  css.includes("var(--font-sans), system-ui, sans-serif"),
+  "global body font stack preserves system fallbacks"
+);
+assert(
+  docs.includes("next/font") &&
+    docs.includes("CLS") &&
+    docs.includes("Lighthouse") &&
+    docs.includes("locales"),
+  "font loading audit documents next/font, CLS, Lighthouse, and locale coverage"
+);
+
+console.log("font loading audit verified");


### PR DESCRIPTION
## Summary


Hardens the existing `next/font` setup with explicit swap/fallback behavior and adds a documented font-loading audit path for CLS review.

## Changes

- Added explicit `display: "swap"` to both `Inter` and `JetBrains_Mono` in `app/layout.tsx`.
- Added stable fallback stacks for the sans and monospace fonts.
- Documented the current `next/font` usage, CLS/Lighthouse review expectations, locale coverage, and visual review checklist in `docs/font-loading.md`.
- Added `npm run verify:font-loading` as a focused static audit for the font-loading contract.

## Validation

Passed locally:

```sh
npm ci --ignore-scripts --no-audit --no-fund
npm run verify:font-loading
node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package json ok')"
git diff --check
```

Also reran broader existing checks. They still fail on baseline issues outside this font-loading change:

```sh
npm run build -- --no-lint
```

Build reaches type validation, then fails on the existing Framer Motion variant type error in `components/CTABanner.tsx`.

```sh
npm run lint
```

Fails on existing hook-order errors in `components/SignalCard.tsx` and an existing dependency warning in `components/SignalRecommendations.tsx`.

```sh
npm test -- --runInBand
```

Fails because the current Jest/ts-jest setup does not transform TSX JSX in two existing component test files.

I did not claim fresh Lighthouse/visual results because the local production build is currently blocked by the baseline type error above; the PR documents the manual Lighthouse and visual review checklist for maintainers once the baseline build is healthy.
