### PR TITLE
Add image usage audit and guard

### DIFF
--- a/docs/image-usage.md
+++ b/docs/image-usage.md
@@ -1,0 +1,40 @@
+# Image Usage Audit
+
+This audit covers image usage in `app/`, `components/`, and static image assets under `public/`.
+
+## Current Inventory
+
+No current image elements were found in `app/` or `components/`.
+
+- No plain `<img>` tags are present.
+- No `next/image` imports are currently needed because the app shell does not render bitmap or SVG image elements.
+- No CSS image backgrounds are used in the audited source directories.
+- `public/` currently contains locale JSON files only, with no image assets.
+
+Because there are no active image elements, there are no plain `<img>` tags to migrate in this PR and no above-the-fold image that needs `priority` today.
+
+## Policy For Future Images
+
+When a future page or component adds an image:
+
+1. Prefer `next/image` over a plain `<img>` tag for local or remote content images.
+2. Add `sizes` for responsive images that can render at different viewport widths.
+3. Add `priority` only for the single most important above-the-fold image, such as a hero or LCP-critical product image.
+4. Keep decorative vector-only UI in CSS or inline SVG when it is not content imagery.
+5. Update this audit when image inventory changes.
+
+## Lighthouse Review
+
+The current landing page has no rendered content images, so image-specific Lighthouse findings such as oversized images, missing dimensions, or unoptimized image formats should not apply to the current app shell.
+
+When future images are added, run Lighthouse on the landing page and any image-heavy route. The expected outcome is no regression in image-related audits, with `next/image` handling sizing, lazy loading, and optimization where applicable.
+
+## Regression Check
+
+Run the static audit before opening a PR that touches image usage:
+
+```sh
+npm run verify:image-usage
+```
+
+The check fails if new plain `<img>` tags, CSS image backgrounds, or public image assets appear without updating this audit.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:image-usage": "node scripts/verify-image-usage.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/scripts/verify-image-usage.mjs
+++ b/scripts/verify-image-usage.mjs
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const roots = ["app", "components"];
+const imageExtensions = new Set([
+  ".apng",
+  ".avif",
+  ".gif",
+  ".jpeg",
+  ".jpg",
+  ".png",
+  ".svg",
+  ".webp",
+]);
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(fullPath);
+    }
+    return fullPath;
+  });
+}
+
+const sourceFiles = roots
+  .flatMap(walk)
+  .filter((file) => /\.(tsx|ts|jsx|js|css)$/.test(file));
+
+const plainImageTagFiles = [];
+const cssImageFiles = [];
+
+for (const file of sourceFiles) {
+  const contents = fs.readFileSync(file, "utf8");
+  if (/<img\b/.test(contents)) {
+    plainImageTagFiles.push(file);
+  }
+  if (/background-image\s*:|url\(\s*['"]?[^)'"]+\.(png|jpe?g|webp|avif|gif|svg)/i.test(contents)) {
+    cssImageFiles.push(file);
+  }
+}
+
+const publicImageFiles = walk("public").filter((file) =>
+  imageExtensions.has(path.extname(file).toLowerCase())
+);
+
+assert(
+  plainImageTagFiles.length === 0,
+  `plain <img> tags found: ${plainImageTagFiles.join(", ")}`
+);
+assert(
+  cssImageFiles.length === 0,
+  `CSS image backgrounds found: ${cssImageFiles.join(", ")}`
+);
+assert(
+  publicImageFiles.length === 0,
+  `public image assets need explicit audit: ${publicImageFiles.join(", ")}`
+);
+
+const docs = fs.readFileSync("docs/image-usage.md", "utf8");
+assert(docs.includes("next/image"), "audit documents next/image policy");
+assert(docs.includes("priority"), "audit documents above-the-fold priority policy");
+assert(docs.includes("sizes"), "audit documents responsive sizes policy");
+assert(docs.includes("Lighthouse"), "audit documents Lighthouse image review");
+assert(docs.includes("No current image elements"), "audit records current image inventory");
+
+console.log("image usage audit verified");


### PR DESCRIPTION
## Summary


Adds a static image usage audit and guard for current app/component image usage. The audited app shell currently has no rendered image elements to migrate, so this PR documents the zero-image inventory and adds a regression check to catch future plain `<img>`, CSS image backgrounds, or public image assets without updating the audit.

## Changes

- Added `docs/image-usage.md` documenting the current image inventory.
- Added policy for future `next/image` adoption, responsive `sizes`, above-the-fold `priority`, and Lighthouse review.
- Added `npm run verify:image-usage` to fail on new plain `<img>` tags, CSS image backgrounds, or public image assets without updating the audit.

## Validation

Passed locally:

```sh
npm run verify:image-usage
node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package json ok')"
git diff --check
```

Additional audit checks:

```sh
rg -n "<img\b|from ['\"]next/image|next/image|background-image|url\(" app components lib hooks store public --glob "!node_modules" --glob "!*.json"
find public -maxdepth 3 -type f -print
```

The only source `url(...)` match is the existing `MiniChart` inline SVG gradient, not an image asset. `public/` contains locale JSON files only.

I did not rerun the full app build/lint/test suite for this docs/static-audit-only change. The broader app checks are currently known to fail on unrelated baseline issues documented in the other open PRs.