### PR TITLE
Add persisted store hydration guard

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { PageTransitionPlaceholder } from "@/components/PageTransitionPlaceholde
 import { TradeStatusBanner } from "@/components/TradeStatusBanner";
 import { DevPerfOverlay } from "@/components/DevPerfOverlay";
 import { ScrollRestoration } from "@/components/ScrollRestoration";
+import { PersistedStoreHydration } from "@/components/PersistedStoreHydration";
 
 const inter = Inter({
   variable: "--font-sans",
@@ -40,6 +41,7 @@ export default function RootLayout({
       </head>
       <body className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}>
         <Providers>
+          <PersistedStoreHydration />
           <ScrollRestoration />
           <Navbar />
           <PageTransitionPlaceholder />

--- a/components/DemoModeCallout.tsx
+++ b/components/DemoModeCallout.tsx
@@ -5,7 +5,11 @@ import { useDemoModeStore } from "@/store/useDemoModeStore";
 import { cn } from "@/lib/utils";
 
 export function DemoModeCallout({ className }: { className?: string }) {
-  const { setDemoMode } = useDemoModeStore();
+  const { isDemoMode, isHydrated, setDemoMode } = useDemoModeStore();
+
+  if (!isHydrated || !isDemoMode) {
+    return null;
+  }
 
   return (
     <div

--- a/components/DemoModeToggle.tsx
+++ b/components/DemoModeToggle.tsx
@@ -6,24 +6,33 @@ import { useDemoModeStore } from "@/store/useDemoModeStore";
 import { cn } from "@/lib/utils";
 
 export function DemoModeToggle({ className }: { className?: string }) {
-  const { isDemoMode, toggleDemoMode } = useDemoModeStore();
+  const { isDemoMode, isHydrated, toggleDemoMode } = useDemoModeStore();
+  const active = isHydrated && isDemoMode;
 
   return (
     <button
       onClick={toggleDemoMode}
-      aria-pressed={isDemoMode}
-      aria-label={isDemoMode ? "Exit demo mode" : "Enter demo mode"}
+      disabled={!isHydrated}
+      aria-pressed={active}
+      aria-label={
+        !isHydrated
+          ? "Loading demo mode preference"
+          : active
+            ? "Exit demo mode"
+            : "Enter demo mode"
+      }
       className={cn(
         "flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        isDemoMode
+        active
           ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30"
           : "bg-foreground/5 text-foreground-muted hover:bg-foreground/10 hover:text-foreground",
+        !isHydrated && "cursor-not-allowed opacity-60 hover:bg-foreground/5 hover:text-foreground-muted",
         className
       )}
     >
       <Play size={12} aria-hidden="true" />
       <span>Demo Mode</span>
-      {isDemoMode && (
+      {active && (
         <span className="ml-1 rounded bg-blue-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
           ON
         </span>

--- a/components/OnboardingFlow.tsx
+++ b/components/OnboardingFlow.tsx
@@ -33,9 +33,10 @@ const STEPS: OnboardingStep[] = [
 ];
 
 export function OnboardingFlow() {
-  const { dismissed, setCompleted, setDismissed } = useOnboardingStore();
+  const { dismissed, isHydrated, setCompleted, setDismissed } = useOnboardingStore();
   const [step, setStep] = useState(0);
 
+  if (!isHydrated) return null;
   if (dismissed) return null;
 
   const current = STEPS[step];

--- a/components/PersistedStoreHydration.tsx
+++ b/components/PersistedStoreHydration.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { useBookmarkStore } from "@/store/useBookmarkStore";
+import { useComparisonStore } from "@/store/useComparisonStore";
+import { useDemoModeStore } from "@/store/useDemoModeStore";
+import { useOnboardingStore } from "@/store/useOnboardingStore";
+import { usePortfolioStore } from "@/store/usePortfolioStore";
+import { usePositionLimitStore } from "@/store/usePositionLimitStore";
+import { useRecommendationStore } from "@/store/useRecommendationStore";
+import { useSignalFilterStore } from "@/store/useSignalFilterStore";
+import { useThemeStore } from "@/store/useThemeStore";
+import { useWalletStore } from "@/store/useWalletStore";
+import { useWebhookStore } from "@/store/useWebhookStore";
+
+type RehydratableStore = {
+  persist: {
+    rehydrate: () => Promise<void> | void;
+  };
+};
+
+const persistedStores = [
+  useBookmarkStore,
+  useComparisonStore,
+  useDemoModeStore,
+  useOnboardingStore,
+  usePortfolioStore,
+  usePositionLimitStore,
+  useRecommendationStore,
+  useSignalFilterStore,
+  useThemeStore,
+  useWalletStore,
+  useWebhookStore,
+] as RehydratableStore[];
+
+export function PersistedStoreHydration() {
+  useEffect(() => {
+    for (const store of persistedStores) {
+      void store.persist.rehydrate();
+    }
+  }, []);
+
+  return null;
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -9,10 +9,12 @@ import { useEffect } from "react";
  * Mount once (inside Navbar or layout) — it handles DOM sync automatically.
  */
 export function ThemeToggle() {
-  const { theme, toggle } = useThemeStore();
+  const { theme, isHydrated, toggle } = useThemeStore();
 
   // Sync theme class on <html> whenever it changes
   useEffect(() => {
+    if (!isHydrated) return;
+
     const root = document.documentElement;
     if (theme === "light") {
       root.classList.remove("dark");
@@ -21,18 +23,25 @@ export function ThemeToggle() {
       root.classList.remove("light");
       root.classList.add("dark");
     }
-  }, [theme]);
+  }, [isHydrated, theme]);
+
+  const nextTheme = theme === "dark" ? "light" : "dark";
 
   return (
     <button
       type="button"
       onClick={toggle}
-      aria-pressed={theme === "dark"}
-      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-      title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
-      className="flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted transition-colors hover:bg-surface-high/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+      disabled={!isHydrated}
+      aria-pressed={isHydrated ? theme === "dark" : undefined}
+      aria-label={
+        isHydrated ? `Switch to ${nextTheme} mode` : "Loading theme preference"
+      }
+      title={isHydrated ? `Switch to ${nextTheme} mode` : "Loading theme preference"}
+      className="flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted transition-colors hover:bg-surface-high/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-foreground-muted"
     >
-      {theme === "dark" ? (
+      {!isHydrated ? (
+        <span className="h-4 w-4 rounded-full bg-current/30" aria-hidden="true" />
+      ) : theme === "dark" ? (
         <Sun size={16} aria-hidden="true" />
       ) : (
         <Moon size={16} aria-hidden="true" />

--- a/components/__tests__/DemoModeToggle.test.tsx
+++ b/components/__tests__/DemoModeToggle.test.tsx
@@ -10,8 +10,10 @@ describe("DemoModeToggle", () => {
   it("renders toggle button in off state", () => {
     mockUseDemoModeStore.mockReturnValue({
       isDemoMode: false,
+      isHydrated: true,
       toggleDemoMode: jest.fn(),
       setDemoMode: jest.fn(),
+      setHydrated: jest.fn(),
     });
 
     render(<DemoModeToggle />);
@@ -22,8 +24,10 @@ describe("DemoModeToggle", () => {
   it("renders toggle button in on state", () => {
     mockUseDemoModeStore.mockReturnValue({
       isDemoMode: true,
+      isHydrated: true,
       toggleDemoMode: jest.fn(),
       setDemoMode: jest.fn(),
+      setHydrated: jest.fn(),
     });
 
     render(<DemoModeToggle />);
@@ -35,12 +39,34 @@ describe("DemoModeToggle", () => {
     const mockToggle = jest.fn();
     mockUseDemoModeStore.mockReturnValue({
       isDemoMode: false,
+      isHydrated: true,
       toggleDemoMode: mockToggle,
       setDemoMode: jest.fn(),
+      setHydrated: jest.fn(),
     });
 
     render(<DemoModeToggle />);
     fireEvent.click(screen.getByRole("button", { name: /enter demo mode/i }));
     expect(mockToggle).toHaveBeenCalled();
+  });
+
+  it("disables the toggle until the persisted value is hydrated", () => {
+    const mockToggle = jest.fn();
+    mockUseDemoModeStore.mockReturnValue({
+      isDemoMode: true,
+      isHydrated: false,
+      toggleDemoMode: mockToggle,
+      setDemoMode: jest.fn(),
+      setHydrated: jest.fn(),
+    });
+
+    render(<DemoModeToggle />);
+
+    const button = screen.getByRole("button", { name: /loading demo mode/i });
+    expect(button).toHaveProperty("disabled", true);
+    expect(screen.queryByText("ON")).toBeNull();
+
+    fireEvent.click(button);
+    expect(mockToggle).not.toHaveBeenCalled();
   });
 });

--- a/docs/persisted-store-hydration.md
+++ b/docs/persisted-store-hydration.md
@@ -1,0 +1,38 @@
+# Persisted Zustand Store Hydration
+
+Persisted Zustand stores should not read `localStorage` during the first client render. In Next.js that can make the client render a saved value while the server HTML was produced from the default value, causing hydration mismatch warnings and visible flicker.
+
+## Shared Pattern
+
+Every persisted store must use `createPersistedState` and `withPersistedHydration` from `store/persistHydration.ts`.
+
+The helper adds:
+
+- `isHydrated`, initially `false`
+- `setHydrated`, used by the persist lifecycle
+- `skipHydration: true`, so `localStorage` is not read synchronously during the first client render
+- a shared `partialize` wrapper, so runtime hydration flags are not written back into `localStorage`
+
+The root layout mounts `PersistedStoreHydration`, which calls `store.persist.rehydrate()` after the app has mounted. Components render the same default state on the server and initial client render, then update after the persisted state has been loaded.
+
+## Component Guidance
+
+Components that expose persisted values directly in labels, icons, modals, or high-visibility controls should read `isHydrated` and render a neutral loading state until it is `true`.
+
+Examples:
+
+- theme controls should avoid showing the saved theme icon before hydration
+- onboarding should not flash before the saved dismissed/completed state is loaded
+- filters, bookmarks, wallets, and saved settings should rely on the root rehydration pass before showing persisted values
+
+## Adding A New Persisted Store
+
+1. Extend the store interface with `PersistHydrationState`.
+2. Spread `createPersistedState(set)` into the initial store state.
+3. Wrap persist options with `withPersistedHydration`.
+4. Add the store to `components/PersistedStoreHydration.tsx`.
+5. Run:
+
+```sh
+npm run verify:persist-hydration
+```

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:persist-hydration": "node scripts/verify-persisted-hydration.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/scripts/verify-persisted-hydration.mjs
+++ b/scripts/verify-persisted-hydration.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const storeDir = "store";
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const storeFiles = fs
+  .readdirSync(storeDir)
+  .filter((file) => file.endsWith(".ts"))
+  .map((file) => path.join(storeDir, file));
+
+const persistedStoreFiles = storeFiles.filter((file) =>
+  fs.readFileSync(file, "utf8").includes("persist(")
+);
+
+assert(persistedStoreFiles.length > 0, "expected persisted Zustand stores");
+
+for (const file of persistedStoreFiles) {
+  const source = fs.readFileSync(file, "utf8");
+  assert(
+    source.includes("createPersistedState") &&
+      source.includes("withPersistedHydration"),
+    `${file} must use the shared persisted hydration helper`
+  );
+  assert(
+    source.includes("PersistHydrationState"),
+    `${file} must expose isHydrated through PersistHydrationState`
+  );
+}
+
+const helper = fs.readFileSync("store/persistHydration.ts", "utf8");
+assert(
+  helper.includes("skipHydration: true"),
+  "shared hydration helper must opt persisted stores out of sync localStorage hydration"
+);
+assert(
+  helper.includes("partialize") &&
+    helper.includes("isHydrated") &&
+    helper.includes("setHydrated"),
+  "shared hydration helper must keep runtime hydration flags out of persisted storage"
+);
+
+const hydrationComponent = fs.readFileSync(
+  "components/PersistedStoreHydration.tsx",
+  "utf8"
+);
+
+for (const file of persistedStoreFiles) {
+  const exportName = path.basename(file, ".ts");
+  assert(
+    hydrationComponent.includes(exportName),
+    `PersistedStoreHydration must rehydrate ${exportName}`
+  );
+}
+
+const layout = fs.readFileSync("app/layout.tsx", "utf8");
+assert(
+  layout.includes("<PersistedStoreHydration />"),
+  "Root layout must mount PersistedStoreHydration"
+);
+
+const docs = fs.readFileSync("docs/persisted-store-hydration.md", "utf8");
+assert(
+  docs.includes("skipHydration") && docs.includes("isHydrated"),
+  "hydration docs must describe skipHydration and isHydrated"
+);
+
+console.log(
+  `persisted hydration verified for ${persistedStoreFiles.length} stores`
+);

--- a/store/persistHydration.ts
+++ b/store/persistHydration.ts
@@ -1,0 +1,47 @@
+import type { PersistOptions } from "zustand/middleware";
+
+export interface PersistHydrationState {
+  isHydrated: boolean;
+  setHydrated: (isHydrated: boolean) => void;
+}
+
+type HydrationSetter<T extends PersistHydrationState> = (
+  partial: Partial<T>
+) => void;
+
+export function createPersistedState<T extends PersistHydrationState>(
+  set: HydrationSetter<T>
+): PersistHydrationState {
+  return {
+    isHydrated: false,
+    setHydrated: (isHydrated) => set({ isHydrated } as Partial<T>),
+  };
+}
+
+export function withPersistedHydration<T extends PersistHydrationState>(
+  options: PersistOptions<T>
+): PersistOptions<T> {
+  const onRehydrateStorage = options.onRehydrateStorage;
+  const partialize = options.partialize;
+
+  return {
+    ...options,
+    skipHydration: true,
+    partialize: (state) => {
+      const persistedState = partialize ? partialize(state) : state;
+      const { isHydrated: _isHydrated, setHydrated: _setHydrated, ...rest } =
+        persistedState as PersistHydrationState & Record<string, unknown>;
+
+      return rest as unknown as T;
+    },
+    onRehydrateStorage: (state) => {
+      state.setHydrated(false);
+      const afterRehydrate = onRehydrateStorage?.(state);
+
+      return (rehydratedState, error) => {
+        afterRehydrate?.(rehydratedState, error);
+        (rehydratedState ?? state).setHydrated(!error);
+      };
+    },
+  };
+}

--- a/store/useBookmarkStore.ts
+++ b/store/useBookmarkStore.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
-interface BookmarkState {
+interface BookmarkState extends PersistHydrationState {
   bookmarks: string[];
   toggleBookmark: (id: string) => void;
   clearBookmarks: () => void;
@@ -10,6 +15,7 @@ interface BookmarkState {
 export const useBookmarkStore = create<BookmarkState>()(
   persist(
     (set) => ({
+      ...createPersistedState<BookmarkState>(set),
       bookmarks: [],
       toggleBookmark: (id: string) =>
         set((state) => ({
@@ -19,6 +25,6 @@ export const useBookmarkStore = create<BookmarkState>()(
         })),
       clearBookmarks: () => set({ bookmarks: [] }),
     }),
-    { name: "signal-bookmarks" }
+    withPersistedHydration({ name: "signal-bookmarks" })
   )
 );

--- a/store/useComparisonStore.ts
+++ b/store/useComparisonStore.ts
@@ -1,10 +1,15 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { Signal } from "@/lib/api";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
 const MAX_SIGNALS = 3;
 
-interface ComparisonState {
+interface ComparisonState extends PersistHydrationState {
   signals: Signal[];
   hiddenMetrics: string[];
   addSignal: (signal: Signal) => boolean;
@@ -18,6 +23,7 @@ interface ComparisonState {
 export const useComparisonStore = create<ComparisonState>()(
   persist(
     (set, get) => ({
+      ...createPersistedState<ComparisonState>(set),
       signals: [],
       hiddenMetrics: [],
 
@@ -44,6 +50,6 @@ export const useComparisonStore = create<ComparisonState>()(
       isSelected: (id) => get().signals.some((s) => s.id === id),
       canAdd: () => get().signals.length < MAX_SIGNALS,
     }),
-    { name: "signal-comparison" }
+    withPersistedHydration({ name: "signal-comparison" })
   )
 );

--- a/store/useDemoModeStore.ts
+++ b/store/useDemoModeStore.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
-export interface DemoState {
+export interface DemoState extends PersistHydrationState {
   isDemoMode: boolean;
   toggleDemoMode: () => void;
   setDemoMode: (enabled: boolean) => void;
@@ -10,10 +15,11 @@ export interface DemoState {
 export const useDemoModeStore = create<DemoState>()(
   persist(
     (set) => ({
+      ...createPersistedState<DemoState>(set),
       isDemoMode: false,
       toggleDemoMode: () => set((state) => ({ isDemoMode: !state.isDemoMode })),
       setDemoMode: (enabled) => set({ isDemoMode: enabled }),
     }),
-    { name: "demo-mode-store" }
+    withPersistedHydration({ name: "demo-mode-store" })
   )
 );

--- a/store/useOnboardingStore.ts
+++ b/store/useOnboardingStore.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
-interface OnboardingState {
+interface OnboardingState extends PersistHydrationState {
   completed: boolean;
   dismissed: boolean;
   setCompleted: () => void;
@@ -12,12 +17,13 @@ interface OnboardingState {
 export const useOnboardingStore = create<OnboardingState>()(
   persist(
     (set) => ({
+      ...createPersistedState<OnboardingState>(set),
       completed: false,
       dismissed: false,
       setCompleted: () => set({ completed: true, dismissed: true }),
       setDismissed: () => set({ dismissed: true }),
       reset: () => set({ completed: false, dismissed: false }),
     }),
-    { name: "stellar-onboarding" }
+    withPersistedHydration({ name: "stellar-onboarding" })
   )
 );

--- a/store/usePortfolioStore.ts
+++ b/store/usePortfolioStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
 export interface PortfolioAsset {
   symbol: string;
@@ -11,7 +16,7 @@ export interface PortfolioAsset {
   unrealizedPnL?: number;
 }
 
-export interface PortfolioState {
+export interface PortfolioState extends PersistHydrationState {
   assets: PortfolioAsset[];
   totalValue: number;
   totalRealizedPnL: number;
@@ -28,6 +33,7 @@ export interface PortfolioState {
 export const usePortfolioStore = create<PortfolioState>()(
   persist(
     (set, get) => ({
+      ...createPersistedState<PortfolioState>(set),
       assets: [],
       totalValue: 0,
       totalRealizedPnL: 0,
@@ -65,6 +71,6 @@ export const usePortfolioStore = create<PortfolioState>()(
       },
       clear: () => set({ assets: [], totalValue: 0, totalRealizedPnL: 0, totalUnrealizedPnL: 0, lastUpdated: null }),
     }),
-    { name: "portfolio-store" }
+    withPersistedHydration({ name: "portfolio-store" })
   )
 );

--- a/store/usePositionLimitStore.ts
+++ b/store/usePositionLimitStore.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
-interface PositionLimitState {
+interface PositionLimitState extends PersistHydrationState {
   enabled: boolean;
   percentage: number; // e.g., 5 = 5%
   setEnabled: (enabled: boolean) => void;
@@ -12,12 +17,13 @@ interface PositionLimitState {
 export const usePositionLimitStore = create<PositionLimitState>()(
   persist(
     (set) => ({
+      ...createPersistedState<PositionLimitState>(set),
       enabled: false,
       percentage: 5,
       setEnabled: (enabled) => set({ enabled }),
       setPercentage: (percentage) => set({ percentage }),
       toggle: () => set((state) => ({ enabled: !state.enabled })),
     }),
-    { name: "position-limit-store" }
+    withPersistedHydration({ name: "position-limit-store" })
   )
 );

--- a/store/useRecommendationStore.ts
+++ b/store/useRecommendationStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from './persistHydration';
 
 export type RiskProfile = 'conservative' | 'moderate' | 'aggressive';
 
@@ -21,7 +26,7 @@ export interface RecommendedSignal {
   reasons: string[];
 }
 
-interface RecommendationStore {
+interface RecommendationStore extends PersistHydrationState {
   settings: RecommendationSettings;
   feedback: RecommendationFeedback[];
   recommendations: RecommendedSignal[];
@@ -35,6 +40,7 @@ interface RecommendationStore {
 export const useRecommendationStore = create<RecommendationStore>()(
   persist(
     (set) => ({
+      ...createPersistedState<RecommendationStore>(set),
       settings: { enabled: true, riskProfile: 'moderate', privacyAccepted: false },
       feedback: [],
       recommendations: [],
@@ -61,6 +67,6 @@ export const useRecommendationStore = create<RecommendationStore>()(
           },
         })),
     }),
-    { name: 'stellarswipe:recommendations' }
+    withPersistedHydration({ name: 'stellarswipe:recommendations' })
   )
 );

--- a/store/useSignalFilterStore.ts
+++ b/store/useSignalFilterStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
 export type FilterDirection = "ALL" | "BUY" | "SELL";
 export type FeedSortOrder = "latest" | "hot" | "relevant" | "confidence";
@@ -12,7 +17,7 @@ export const SORT_ORDER_LABELS: Record<FeedSortOrder, string> = {
   confidence: "Confidence",
 };
 
-interface SignalFilterState {
+interface SignalFilterState extends PersistHydrationState {
   direction: FilterDirection;
   asset: string;
   provider: string;
@@ -29,6 +34,7 @@ interface SignalFilterState {
 export const useSignalFilterStore = create<SignalFilterState>()(
   persist(
     (set) => ({
+      ...createPersistedState<SignalFilterState>(set),
       direction: "ALL",
       asset: "",
       provider: "",
@@ -48,6 +54,6 @@ export const useSignalFilterStore = create<SignalFilterState>()(
           sortOrder: "latest",
         }),
     }),
-    { name: "signal-filter-store" }
+    withPersistedHydration({ name: "signal-filter-store" })
   )
 );

--- a/store/useThemeStore.ts
+++ b/store/useThemeStore.ts
@@ -1,11 +1,16 @@
 "use client";
 
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
 type Theme = "dark" | "light";
 
-interface ThemeState {
+interface ThemeState extends PersistHydrationState {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   toggle: () => void;
@@ -14,13 +19,14 @@ interface ThemeState {
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set, get) => ({
+      ...createPersistedState<ThemeState>(set),
       theme: "dark",
       setTheme: (theme) => set({ theme }),
       toggle: () => set({ theme: get().theme === "dark" ? "light" : "dark" }),
     }),
-    {
+    withPersistedHydration({
       name: "stellar-theme",
-      getStorage: () => (typeof window !== "undefined" ? localStorage : undefined),
-    }
+      storage: createJSONStorage(() => localStorage),
+    })
   )
 );

--- a/store/useWalletStore.ts
+++ b/store/useWalletStore.ts
@@ -1,7 +1,12 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from "./persistHydration";
 
-interface WalletState {
+interface WalletState extends PersistHydrationState {
   publicKey: string | null;
   isConnected: boolean;
   network: string;
@@ -13,6 +18,7 @@ interface WalletState {
 export const useWalletStore = create<WalletState>()(
   persist(
     (set) => ({
+      ...createPersistedState<WalletState>(set),
       publicKey: null,
       isConnected: false,
       network: "TESTNET",
@@ -20,6 +26,6 @@ export const useWalletStore = create<WalletState>()(
       setConnected: (connected) => set({ isConnected: connected }),
       disconnect: () => set({ publicKey: null, isConnected: false }),
     }),
-    { name: "wallet-store" }
+    withPersistedHydration({ name: "wallet-store" })
   )
 );

--- a/store/useWebhookStore.ts
+++ b/store/useWebhookStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import {
+  createPersistedState,
+  type PersistHydrationState,
+  withPersistedHydration,
+} from './persistHydration';
 
 export type WebhookEventType = 'new_signal' | 'trade_execution' | 'portfolio_alert';
 
@@ -21,7 +26,7 @@ export interface Webhook {
   rateLimit: number; // remaining calls this minute
 }
 
-interface WebhookStore {
+interface WebhookStore extends PersistHydrationState {
   webhooks: Webhook[];
   addWebhook: (url: string, events: WebhookEventType[]) => Webhook;
   removeWebhook: (id: string) => void;
@@ -40,6 +45,7 @@ function generateSecret(): string {
 export const useWebhookStore = create<WebhookStore>()(
   persist(
     (set) => ({
+      ...createPersistedState<WebhookStore>(set),
       webhooks: [],
 
       addWebhook: (url, events) => {
@@ -83,6 +89,6 @@ export const useWebhookStore = create<WebhookStore>()(
       resetRateLimits: () =>
         set((s) => ({ webhooks: s.webhooks.map((w) => ({ ...w, rateLimit: 60 })) })),
     }),
-    { name: 'stellarswipe:webhooks' }
+    withPersistedHydration({ name: 'stellarswipe:webhooks' })
   )
 );


### PR DESCRIPTION
## Summary


- Add a shared persisted Zustand hydration helper that sets `skipHydration: true`, exposes `isHydrated`, and keeps runtime hydration flags out of localStorage.
- Manually rehydrate all current persisted stores from a root client component after mount.
- Gate persisted-dependent theme, demo mode, and onboarding UI until the persisted state is hydrated.
- Document the pattern and add a static verifier so future persisted stores adopt it.

## Validation

- PASS `npm run verify:persist-hydration`
- PASS `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json parsed')"`
- PASS `git diff --check`
- BLOCKED `npm test -- components/__tests__/DemoModeToggle.test.tsx --runInBand`: Jest fails before running tests because the current Jest/TSX setup leaves JSX untransformed (`Unexpected token '<'`).
- BLOCKED `npx tsc --noEmit --pretty false`: existing baseline errors remain, including missing `@testing-library/react`, Framer `Variants` typing in `components/CTABanner.tsx`, and unrelated existing errors in `SignalCard`, `TradeModal`, and `usePortfolio`.
- BLOCKED `npm run lint`: existing conditional hook errors in `components/SignalCard.tsx`.
- BLOCKED `npm run build -- --no-lint`: type checking stops on the existing `components/CTABanner.tsx` Framer `Variants` error.
