### PR TITLE
Add scoped feature error boundaries

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -23,11 +23,15 @@ import { OnChainConfirmationStatus } from "@/components/OnChainConfirmationStatu
 import { TransactionActivityFeed } from "@/components/TransactionActivityFeed";
 import { PositionStopLossControl } from "@/components/PositionStopLossControl";
 import { OnboardingFlow } from "@/components/OnboardingFlow";
+import {
+  ErrorBoundaryTestProbe,
+  ScopedErrorBoundary,
+} from "@/components/ScopedErrorBoundary";
 
 export default function AppPage() {
   const { publicKey, connected } = useWallet();
   const { data: signals, isLoading, error, refetch } = useSignals();
-  const { assets } = usePortfolio();
+  const { assets, refetch: refetchPortfolio } = usePortfolio();
   const { direction, asset, provider } = useSignalFilterStore();
   const addTransaction = useTransactionStore((state) => state.addTransaction);
   const pendingTransaction = useTransactionStore((state) =>
@@ -144,70 +148,100 @@ export default function AppPage() {
         <div className="mx-auto w-full max-w-7xl">
           <div className="grid grid-cols-1 gap-6 md:grid-cols-[minmax(0,1fr)_320px] lg:grid-cols-[minmax(0,1fr)_380px] lg:gap-8">
             <div className="flex flex-col gap-4 min-w-0">
-              <SignalFeedFilters
-                availableAssets={availableAssets}
-                availableProviders={availableProviders}
-              />
-
-              <div className="rounded-3xl border border-border bg-card p-4 shadow-sm sm:p-5">
-                {isLoading && (
-                  <div className="flex justify-center py-10">
-                    <Loader2 className="h-6 w-6 animate-spin text-foreground-muted" />
-                  </div>
-                )}
-
-                {error && (
-                  <SignalErrorState error={error as Error} onRetry={refetch} />
-                )}
-
-                {filteredSignals && filteredSignals.length === 0 && (
-                  <p className="text-center text-sm text-foreground-muted">No signals available.</p>
-                )}
-
-                {filteredSignals && filteredSignals.length > 0 && (
-                  <ul className="flex flex-col gap-3" role="list" aria-label="Signal list">
-                    {filteredSignals.map((signal) => (
-                      <li
-                        key={signal.id}
-                        className="rounded-xl border border-border p-3 text-sm flex flex-wrap items-center justify-between gap-2 sm:p-4"
-                      >
-                        <span className="font-medium text-base sm:text-sm text-foreground">{signal.asset}</span>
-                        <span
-                          className={`rounded-full px-2 py-0.5 text-xs font-semibold ${signal.action === "BUY" ? "bg-green-500/15 text-green-400" : signal.action === "SELL" ? "bg-red-500/15 text-red-400" : "bg-slate-500/15 text-slate-400"}`}
-                        >
-                          {signal.action}
-                        </span>
-                        <span className="text-muted-foreground text-xs">{signal.confidence}% confidence</span>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-
-              <div className="flex w-full max-w-md flex-col items-center gap-3 px-4 sm:px-0">
-                <SignalCard
-                  loading={loading}
-                  onTrade={handleTrade}
-                  providerStake={50000}
-                  providerReputation={85}
-                  portfolioBalance={assets.reduce((sum, asset) => sum + asset.value, 0)}
+              <ScopedErrorBoundary
+                sectionName="signal-feed"
+                sectionLabel="Signal feed"
+                onRetry={() => void refetch()}
+                resetKeys={[direction, asset, provider]}
+              >
+                <ErrorBoundaryTestProbe sectionName="signal-feed" />
+                <SignalFeedFilters
+                  availableAssets={availableAssets}
+                  availableProviders={availableProviders}
                 />
-                <div className="flex gap-3">
-                  <button
-                    onClick={toggleLoading}
-                    className="text-xs text-foreground-subtle hover:text-foreground-muted underline transition-colors"
-                  >
-                    Preview skeleton
-                  </button>
-                  <button
-                    onClick={() => setModalOpen(true)}
-                    className="text-xs text-foreground-subtle hover:text-foreground-muted underline transition-colors"
-                  >
-                    Open trade modal
-                  </button>
+
+                <div className="rounded-3xl border border-border bg-card p-4 shadow-sm sm:p-5">
+                  {isLoading && (
+                    <div className="flex justify-center py-10">
+                      <Loader2 className="h-6 w-6 animate-spin text-foreground-muted" />
+                    </div>
+                  )}
+
+                  {error && (
+                    <SignalErrorState error={error as Error} onRetry={refetch} />
+                  )}
+
+                  {filteredSignals && filteredSignals.length === 0 && (
+                    <p className="text-center text-sm text-foreground-muted">No signals available.</p>
+                  )}
+
+                  {filteredSignals && filteredSignals.length > 0 && (
+                    <ul className="flex flex-col gap-3" role="list" aria-label="Signal list">
+                      {filteredSignals.map((signal) => (
+                        <li
+                          key={signal.id}
+                          className="rounded-xl border border-border p-3 text-sm flex flex-wrap items-center justify-between gap-2 sm:p-4"
+                        >
+                          <span className="font-medium text-base sm:text-sm text-foreground">{signal.asset}</span>
+                          <span
+                            className={`rounded-full px-2 py-0.5 text-xs font-semibold ${signal.action === "BUY" ? "bg-green-500/15 text-green-400" : signal.action === "SELL" ? "bg-red-500/15 text-red-400" : "bg-slate-500/15 text-slate-400"}`}
+                          >
+                            {signal.action}
+                          </span>
+                          <span className="text-muted-foreground text-xs">{signal.confidence}% confidence</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
-              </div>
+              </ScopedErrorBoundary>
+
+              <ScopedErrorBoundary
+                sectionName="trade-preview"
+                sectionLabel="Trade preview"
+                onRetry={() => setLoading(false)}
+              >
+                <ErrorBoundaryTestProbe sectionName="trade-preview" />
+                <div className="flex w-full max-w-md flex-col items-center gap-3 px-4 sm:px-0">
+                  <SignalCard
+                    loading={loading}
+                    onTrade={handleTrade}
+                    providerStake={50000}
+                    providerReputation={85}
+                    portfolioBalance={assets.reduce((sum, asset) => sum + asset.value, 0)}
+                  />
+                  <div className="flex gap-3">
+                    <button
+                      onClick={toggleLoading}
+                      className="text-xs text-foreground-subtle hover:text-foreground-muted underline transition-colors"
+                    >
+                      Preview skeleton
+                    </button>
+                    <button
+                      onClick={() => setModalOpen(true)}
+                      className="text-xs text-foreground-subtle hover:text-foreground-muted underline transition-colors"
+                    >
+                      Open trade modal
+                    </button>
+                  </div>
+                </div>
+              </ScopedErrorBoundary>
             </div>
+
+            <ScopedErrorBoundary
+              sectionName="portfolio-dashboard"
+              sectionLabel="Portfolio dashboard"
+              onRetry={() => void refetchPortfolio()}
+            >
+              <ErrorBoundaryTestProbe sectionName="portfolio-dashboard" />
+              <aside className="flex min-w-0 flex-col gap-4">
+                <PortfolioSummaryCards />
+                <PortfolioAllocationChart />
+                <PnLWidget />
+                <PositionStopLossControl />
+                <TransactionActivityFeed />
+              </aside>
+            </ScopedErrorBoundary>
           </div>
         </div>
 

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -10,6 +10,10 @@ import { ComparisonCard } from "@/components/comparison/ComparisonCard";
 import { MetricToggleBar } from "@/components/comparison/MetricToggleBar";
 import { ComparisonChart } from "@/components/comparison/ComparisonChart";
 import { AddSignalPanel } from "@/components/comparison/AddSignalPanel";
+import {
+  ErrorBoundaryTestProbe,
+  ScopedErrorBoundary,
+} from "@/components/ScopedErrorBoundary";
 
 function computeBestValues(signals: ReturnType<typeof useComparisonStore.getState>["signals"]): Record<string, number> {
   const best: Record<string, number> = {};
@@ -77,95 +81,104 @@ export default function ComparePage() {
             </div>
           </div>
 
-          {/* Add signal panel */}
-          <AnimatePresence>
-            {addPanelOpen && (
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: "auto" }}
-                exit={{ opacity: 0, height: 0 }}
-                className="overflow-hidden mb-6"
-              >
-                <div className="rounded-xl border border-white/10 bg-gray-900 p-4">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-sm font-semibold text-gray-300">Select signals to compare</h2>
-                    <span className="text-xs text-gray-500">{signals.length}/3 selected</span>
-                  </div>
-                  <AddSignalPanel />
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+          <ScopedErrorBoundary
+            sectionName="comparison-tool"
+            sectionLabel="Signal comparison"
+            onRetry={() => setAddPanelOpen(false)}
+            resetKeys={[signals.length]}
+          >
+            <ErrorBoundaryTestProbe sectionName="comparison-tool" />
 
-          {signals.length === 0 ? (
-            /* Empty state */
-            <div className="flex flex-col items-center justify-center py-24 text-center">
-              <GitCompare className="h-12 w-12 text-gray-700 mb-4" />
-              <h2 className="text-xl font-semibold text-gray-400 mb-2">No signals selected</h2>
-              <p className="text-gray-500 text-sm mb-6 max-w-sm">
-                Add up to 3 signals to compare their metrics, entry/exit points, and performance side-by-side.
-              </p>
-              <Button onClick={() => setAddPanelOpen(true)} className="gap-2">
-                <Plus className="h-4 w-4" />
-                Add Your First Signal
-              </Button>
-            </div>
-          ) : (
-            <>
-              {/* Metric toggles */}
-              <div className="mb-6 print:hidden">
-                <p className="text-xs text-gray-400 mb-2 font-medium uppercase tracking-wider">Toggle Columns</p>
-                <MetricToggleBar hiddenMetrics={hiddenMetrics} onToggle={toggleMetric} />
-              </div>
-
-              {/* Side-by-side cards — horizontal scroll on mobile */}
-              <div className="overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0">
-                <div className="flex gap-4" style={{ minWidth: `${signals.length * 220}px` }}>
-                  {signals.map((signal) => (
-                    <motion.div
-                      key={signal.id}
-                      initial={{ opacity: 0, scale: 0.95 }}
-                      animate={{ opacity: 1, scale: 1 }}
-                      exit={{ opacity: 0, scale: 0.95 }}
-                      className="flex-1"
-                      style={{ minWidth: 200 }}
-                    >
-                      <ComparisonCard
-                        signal={signal}
-                        onRemove={() => removeSignal(signal.id)}
-                        hiddenMetrics={hiddenMetrics}
-                        bestValues={bestValues}
-                      />
-                    </motion.div>
-                  ))}
-
-                  {/* Placeholder slot when fewer than 3 */}
-                  {canAdd() && (
-                    <div
-                      className="flex-1 flex items-center justify-center rounded-xl border-2 border-dashed border-white/10 min-h-[200px] cursor-pointer hover:border-white/20 transition-colors print:hidden"
-                      style={{ minWidth: 200 }}
-                      onClick={() => setAddPanelOpen(true)}
-                      role="button"
-                      aria-label="Add another signal"
-                    >
-                      <div className="text-center text-gray-600">
-                        <Plus className="h-8 w-8 mx-auto mb-2" />
-                        <p className="text-sm">Add signal</p>
-                      </div>
+            {/* Add signal panel */}
+            <AnimatePresence>
+              {addPanelOpen && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  className="overflow-hidden mb-6"
+                >
+                  <div className="rounded-xl border border-white/10 bg-gray-900 p-4">
+                    <div className="flex items-center justify-between mb-4">
+                      <h2 className="text-sm font-semibold text-gray-300">Select signals to compare</h2>
+                      <span className="text-xs text-gray-500">{signals.length}/3 selected</span>
                     </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Performance chart */}
-              {signals.length >= 2 && (
-                <div className="mt-8 rounded-xl border border-white/10 bg-gray-900 p-6">
-                  <h2 className="text-sm font-semibold text-gray-300 mb-5">Performance Comparison</h2>
-                  <ComparisonChart signals={signals} />
-                </div>
+                    <AddSignalPanel />
+                  </div>
+                </motion.div>
               )}
-            </>
-          )}
+            </AnimatePresence>
+
+            {signals.length === 0 ? (
+              /* Empty state */
+              <div className="flex flex-col items-center justify-center py-24 text-center">
+                <GitCompare className="h-12 w-12 text-gray-700 mb-4" />
+                <h2 className="text-xl font-semibold text-gray-400 mb-2">No signals selected</h2>
+                <p className="text-gray-500 text-sm mb-6 max-w-sm">
+                  Add up to 3 signals to compare their metrics, entry/exit points, and performance side-by-side.
+                </p>
+                <Button onClick={() => setAddPanelOpen(true)} className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  Add Your First Signal
+                </Button>
+              </div>
+            ) : (
+              <>
+                {/* Metric toggles */}
+                <div className="mb-6 print:hidden">
+                  <p className="text-xs text-gray-400 mb-2 font-medium uppercase tracking-wider">Toggle Columns</p>
+                  <MetricToggleBar hiddenMetrics={hiddenMetrics} onToggle={toggleMetric} />
+                </div>
+
+                {/* Side-by-side cards — horizontal scroll on mobile */}
+                <div className="overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0">
+                  <div className="flex gap-4" style={{ minWidth: `${signals.length * 220}px` }}>
+                    {signals.map((signal) => (
+                      <motion.div
+                        key={signal.id}
+                        initial={{ opacity: 0, scale: 0.95 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.95 }}
+                        className="flex-1"
+                        style={{ minWidth: 200 }}
+                      >
+                        <ComparisonCard
+                          signal={signal}
+                          onRemove={() => removeSignal(signal.id)}
+                          hiddenMetrics={hiddenMetrics}
+                          bestValues={bestValues}
+                        />
+                      </motion.div>
+                    ))}
+
+                    {/* Placeholder slot when fewer than 3 */}
+                    {canAdd() && (
+                      <div
+                        className="flex-1 flex items-center justify-center rounded-xl border-2 border-dashed border-white/10 min-h-[200px] cursor-pointer hover:border-white/20 transition-colors print:hidden"
+                        style={{ minWidth: 200 }}
+                        onClick={() => setAddPanelOpen(true)}
+                        role="button"
+                        aria-label="Add another signal"
+                      >
+                        <div className="text-center text-gray-600">
+                          <Plus className="h-8 w-8 mx-auto mb-2" />
+                          <p className="text-sm">Add signal</p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Performance chart */}
+                {signals.length >= 2 && (
+                  <div className="mt-8 rounded-xl border border-white/10 bg-gray-900 p-6">
+                    <h2 className="text-sm font-semibold text-gray-300 mb-5">Performance Comparison</h2>
+                    <ComparisonChart signals={signals} />
+                  </div>
+                )}
+              </>
+            )}
+          </ScopedErrorBoundary>
         </div>
       </main>
 

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -6,6 +6,10 @@ import { useLeaderboard } from "@/hooks/useLeaderboard";
 import { SignalProvider } from "@/lib/types";
 import { Loader2, ChevronUp, ChevronDown } from "lucide-react";
 import { PageTransition } from "@/components/PageTransition";
+import {
+  ErrorBoundaryTestProbe,
+  ScopedErrorBoundary,
+} from "@/components/ScopedErrorBoundary";
 
 type SortField = "rank" | "overallScore" | "winRate" | "recentPerformance";
 type SortDirection = "asc" | "desc";
@@ -68,26 +72,6 @@ export default function LeaderboardPage() {
     </button>
   );
 
-  if (isLoading) {
-    return (
-      <PageTransition>
-        <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 sm:gap-8 sm:p-8 bg-gray-950">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-        </main>
-      </PageTransition>
-    );
-  }
-
-  if (error) {
-    return (
-      <PageTransition>
-        <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 sm:gap-8 sm:p-8 bg-gray-950">
-          <p className="text-center text-red-500">Failed to load leaderboard</p>
-        </main>
-      </PageTransition>
-    );
-  }
-
   return (
     <PageTransition>
       <main className="flex min-h-screen flex-col gap-6 p-4 sm:gap-8 sm:p-8 bg-gray-950">
@@ -96,74 +80,99 @@ export default function LeaderboardPage() {
           <p className="text-sm text-gray-400 mt-2">Top-performing signal providers</p>
         </header>
 
-        <div className="w-full overflow-x-auto rounded-lg border bg-card">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/50">
-                <th className="px-4 py-3 text-left font-semibold text-foreground">
-                  <SortHeader field="rank" label="Rank" />
-                </th>
-                <th className="px-4 py-3 text-left font-semibold text-foreground">Provider</th>
-                <th className="px-4 py-3 text-right font-semibold text-foreground">
-                  <SortHeader field="overallScore" label="Score" className="justify-end" />
-                </th>
-                <th className="px-4 py-3 text-right font-semibold text-foreground">
-                  <SortHeader field="winRate" label="Win Rate" className="justify-end" />
-                </th>
-                <th className="px-4 py-3 text-right font-semibold text-foreground">
-                  <SortHeader field="recentPerformance" label="Recent" className="justify-end" />
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedProviders.map((provider) => (
-                <tr
-                  key={provider.id}
-                  className="border-b hover:bg-muted/30 transition-colors cursor-pointer"
-                  onClick={() => router.push(`/provider/${provider.id}`)}
-                  role="link"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      router.push(`/provider/${provider.id}`);
-                    }
-                  }}
-                  aria-label={`View profile for ${provider.name || provider.address}`}
-                >
-                  <td className="px-4 py-3 font-semibold text-foreground">#{provider.rank}</td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-col gap-0.5">
-                      {provider.name && (
-                        <p className="font-medium text-foreground">{provider.name}</p>
-                      )}
-                      <p className="text-xs text-muted-foreground font-mono">
-                        {truncateAddress(provider.address)}
-                      </p>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right font-semibold text-green-600">
-                    {provider.overallScore}
-                  </td>
-                  <td className="px-4 py-3 text-right font-semibold text-foreground">
-                    {provider.winRate}%
-                  </td>
-                  <td className={`px-4 py-3 text-right font-semibold ${
-                    provider.recentPerformance >= 0 ? "text-green-600" : "text-red-600"
-                  }`}>
-                    {provider.recentPerformance >= 0 ? "+" : ""}{provider.recentPerformance}%
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ScopedErrorBoundary
+          sectionName="leaderboard-table"
+          sectionLabel="Leaderboard"
+          onRetry={() => router.refresh()}
+          resetKeys={[sortField, sortDirection]}
+        >
+          <ErrorBoundaryTestProbe sectionName="leaderboard-table" />
 
-        {sortedProviders.length === 0 && (
-          <div className="text-center py-10">
-            <p className="text-muted-foreground">No providers available</p>
-          </div>
-        )}
+          {isLoading && (
+            <div className="flex justify-center rounded-lg border bg-card py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-6 text-center">
+              <p className="text-red-500">Failed to load leaderboard</p>
+            </div>
+          )}
+
+          {!isLoading && !error && (
+            <>
+              <div className="w-full overflow-x-auto rounded-lg border bg-card">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="px-4 py-3 text-left font-semibold text-foreground">
+                        <SortHeader field="rank" label="Rank" />
+                      </th>
+                      <th className="px-4 py-3 text-left font-semibold text-foreground">Provider</th>
+                      <th className="px-4 py-3 text-right font-semibold text-foreground">
+                        <SortHeader field="overallScore" label="Score" className="justify-end" />
+                      </th>
+                      <th className="px-4 py-3 text-right font-semibold text-foreground">
+                        <SortHeader field="winRate" label="Win Rate" className="justify-end" />
+                      </th>
+                      <th className="px-4 py-3 text-right font-semibold text-foreground">
+                        <SortHeader field="recentPerformance" label="Recent" className="justify-end" />
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sortedProviders.map((provider) => (
+                      <tr
+                        key={provider.id}
+                        className="border-b hover:bg-muted/30 transition-colors cursor-pointer"
+                        onClick={() => router.push(`/provider/${provider.id}`)}
+                        role="link"
+                        tabIndex={0}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            router.push(`/provider/${provider.id}`);
+                          }
+                        }}
+                        aria-label={`View profile for ${provider.name || provider.address}`}
+                      >
+                        <td className="px-4 py-3 font-semibold text-foreground">#{provider.rank}</td>
+                        <td className="px-4 py-3">
+                          <div className="flex flex-col gap-0.5">
+                            {provider.name && (
+                              <p className="font-medium text-foreground">{provider.name}</p>
+                            )}
+                            <p className="text-xs text-muted-foreground font-mono">
+                              {truncateAddress(provider.address)}
+                            </p>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-right font-semibold text-green-600">
+                          {provider.overallScore}
+                        </td>
+                        <td className="px-4 py-3 text-right font-semibold text-foreground">
+                          {provider.winRate}%
+                        </td>
+                        <td className={`px-4 py-3 text-right font-semibold ${
+                          provider.recentPerformance >= 0 ? "text-green-600" : "text-red-600"
+                        }`}>
+                          {provider.recentPerformance >= 0 ? "+" : ""}{provider.recentPerformance}%
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {sortedProviders.length === 0 && (
+                <div className="text-center py-10">
+                  <p className="text-muted-foreground">No providers available</p>
+                </div>
+              )}
+            </>
+          )}
+        </ScopedErrorBoundary>
       </main>
     </PageTransition>
   );

--- a/components/ScopedErrorBoundary.tsx
+++ b/components/ScopedErrorBoundary.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Component, ErrorInfo, ReactNode, useEffect, useState } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+
+interface ScopedErrorBoundaryProps {
+  children: ReactNode;
+  sectionLabel: string;
+  sectionName: string;
+  description?: string;
+  onRetry?: () => void | Promise<void>;
+  resetKeys?: unknown[];
+}
+
+interface ScopedErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+function changedResetKeys(previous?: unknown[], next?: unknown[]) {
+  if (!previous || !next || previous.length !== next.length) {
+    return previous !== next;
+  }
+
+  return previous.some((value, index) => value !== next[index]);
+}
+
+export class ScopedErrorBoundary extends Component<
+  ScopedErrorBoundaryProps,
+  ScopedErrorBoundaryState
+> {
+  state: ScopedErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ScopedErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(
+      `[ScopedErrorBoundary:${this.props.sectionName}] Caught an error:`,
+      error
+    );
+    console.error(
+      `[ScopedErrorBoundary:${this.props.sectionName}] Component stack:`,
+      errorInfo.componentStack
+    );
+  }
+
+  componentDidUpdate(previousProps: ScopedErrorBoundaryProps) {
+    if (
+      this.state.hasError &&
+      changedResetKeys(previousProps.resetKeys, this.props.resetKeys)
+    ) {
+      this.setState({ hasError: false, error: null });
+    }
+  }
+
+  handleRetry = async () => {
+    this.setState({ hasError: false, error: null });
+    await this.props.onRetry?.();
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <section
+        role="alert"
+        aria-live="polite"
+        data-feature-boundary-fallback={this.props.sectionName}
+        className="rounded-3xl border border-yellow-500/30 bg-yellow-500/5 p-5 text-foreground shadow-sm"
+      >
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-yellow-500/15 text-yellow-500">
+            <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold">
+              {this.props.sectionLabel} is temporarily unavailable
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {this.props.description ??
+                "Only this section failed. The rest of the page is still available."}
+            </p>
+            {process.env.NODE_ENV === "development" && this.state.error && (
+              <details className="mt-3 rounded-2xl border border-white/10 bg-black/20 p-3">
+                <summary className="cursor-pointer text-xs text-muted-foreground">
+                  Error details
+                </summary>
+                <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground">
+                  {this.state.error.message}
+                </pre>
+              </details>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-foreground transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+            Retry
+          </button>
+        </div>
+      </section>
+    );
+  }
+}
+
+export function ErrorBoundaryTestProbe({ sectionName }: { sectionName: string }) {
+  const [shouldThrow, setShouldThrow] = useState(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    setShouldThrow(params.get("throwFeatureBoundary") === sectionName);
+  }, [sectionName]);
+
+  if (shouldThrow) {
+    throw new Error(`Deliberate ${sectionName} feature boundary test error`);
+  }
+
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:scoped-error-boundaries": "node scripts/verify-scoped-error-boundaries.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/scripts/verify-scoped-error-boundaries.mjs
+++ b/scripts/verify-scoped-error-boundaries.mjs
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+
+const files = {
+  boundary: "components/ScopedErrorBoundary.tsx",
+  app: "app/app/page.tsx",
+  compare: "app/compare/page.tsx",
+  leaderboard: "app/leaderboard/page.tsx",
+  globalBoundary: "app/error-boundary-wrapper.tsx",
+  globalError: "app/error.tsx",
+};
+
+const source = Object.fromEntries(
+  Object.entries(files).map(([key, file]) => [key, readFileSync(file, "utf8")])
+);
+
+const requiredSections = [
+  ["signal-feed", source.app],
+  ["trade-preview", source.app],
+  ["portfolio-dashboard", source.app],
+  ["comparison-tool", source.compare],
+  ["leaderboard-table", source.leaderboard],
+];
+
+const failures = [];
+
+for (const [sectionName, content] of requiredSections) {
+  if (!content.includes(`sectionName="${sectionName}"`)) {
+    failures.push(`Missing ScopedErrorBoundary section: ${sectionName}`);
+  }
+
+  if (!content.includes(`ErrorBoundaryTestProbe sectionName="${sectionName}"`)) {
+    failures.push(`Missing deliberate throw probe for: ${sectionName}`);
+  }
+}
+
+if (!source.boundary.includes("data-feature-boundary-fallback")) {
+  failures.push("Scoped fallback is missing a stable fallback marker");
+}
+
+if (!source.boundary.includes("onRetry")) {
+  failures.push("Scoped fallback is missing retry support");
+}
+
+if (!source.boundary.includes('NODE_ENV === "production"')) {
+  failures.push("Deliberate throw probe is not disabled in production");
+}
+
+if (!source.globalBoundary.includes("<ErrorBoundary>{children}</ErrorBoundary>")) {
+  failures.push("Global ErrorBoundaryProvider is no longer intact");
+}
+
+if (!source.globalError.includes("reset")) {
+  failures.push("Next.js route-level error fallback is no longer intact");
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+console.log("Scoped feature error boundaries verified.");


### PR DESCRIPTION
## Summary
- add a reusable scoped feature error boundary with section-level retry fallback
- wrap signal feed, trade preview, portfolio dashboard, comparison tool, and leaderboard sections so one render failure does not take down the whole page
- add a non-production query-param probe for deliberate boundary checks via `throwFeatureBoundary=<section>`
- keep the existing global/route error boundaries intact as final fallback

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run verify:scoped-error-boundaries`
- `./node_modules/.bin/eslint components/ScopedErrorBoundary.tsx app/app/page.tsx app/compare/page.tsx app/leaderboard/page.tsx`
- `git diff --check`

## Existing baseline blockers
- `npx tsc --noEmit --pretty false` still fails on pre-existing repository issues, including missing `@testing-library/react`, Framer `Variants` typing in `CTABanner`/`FeatureCards`/`HowItWorks`, `SignalCard` missing announcement state, `TradeModal` ordering/argument issues, `usePortfolio` asset typing, and `useThemeStore` persist options.
- `npm run build -- --no-lint` still reaches type-checking and stops at the existing `CTABanner` Framer `Variants` error.
- `npm run lint` still fails on existing conditional hooks in `components/SignalCard.tsx`; the changed files pass focused ESLint.