### PR TITLE
Add forced-colors accessibility support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -292,3 +292,123 @@
   .z-toast     { z-index: var(--z-toast); }
   .z-loading   { z-index: var(--z-loading); }
 }
+
+/* Windows High Contrast / forced-colors support.
+ * Keep this global because the affected classes are mostly Tailwind utility
+ * combinations spread across buttons, badges, toggles, and signal cards.
+ */
+@media (forced-colors: active) {
+  *,
+  *::before,
+  *::after {
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  :where(button, [role="button"], a, input, select, textarea, summary, [tabindex]:not([tabindex="-1"])) {
+    forced-color-adjust: auto;
+  }
+
+  :where(button, [role="button"], a, input, select, textarea, summary, [role="switch"], [aria-pressed]):focus-visible {
+    outline: 2px solid Highlight !important;
+    outline-offset: 3px;
+    box-shadow: none !important;
+  }
+
+  :where(button, [role="button"], [role="switch"], [aria-pressed]) {
+    border-color: ButtonText !important;
+  }
+
+  :where(button, [role="button"], [role="switch"]) {
+    background-color: ButtonFace;
+    color: ButtonText;
+  }
+
+  :where([aria-pressed="true"], [role="switch"][aria-checked="true"]) {
+    forced-color-adjust: none;
+    background-color: Highlight !important;
+    border-color: Highlight !important;
+    color: HighlightText !important;
+  }
+
+  :where([aria-pressed="false"], [role="switch"][aria-checked="false"]) {
+    background-color: ButtonFace !important;
+    border-color: ButtonText !important;
+    color: ButtonText !important;
+  }
+
+  :where(
+    [class*="bg-green-"],
+    [class*="text-green-"],
+    [class*="border-green-"],
+    [class*="bg-emerald-"],
+    [class*="text-emerald-"],
+    [class*="border-emerald-"],
+    [class*="accent-success"]
+  ) {
+    forced-color-adjust: none;
+    background-color: Canvas !important;
+    border-color: CanvasText !important;
+    border-style: solid !important;
+    border-width: 1px !important;
+    color: CanvasText !important;
+  }
+
+  :where(
+    [class*="bg-red-"],
+    [class*="text-red-"],
+    [class*="border-red-"],
+    [class*="destructive"],
+    [class*="accent-danger"]
+  ) {
+    forced-color-adjust: none;
+    background-color: Canvas !important;
+    border-color: CanvasText !important;
+    border-style: double !important;
+    border-width: 3px !important;
+    color: CanvasText !important;
+  }
+
+  :where(
+    [class*="bg-amber-"],
+    [class*="text-amber-"],
+    [class*="border-amber-"],
+    [class*="bg-yellow-"],
+    [class*="text-yellow-"],
+    [class*="border-yellow-"],
+    [class*="bg-orange-"],
+    [class*="text-orange-"],
+    [class*="border-orange-"],
+    [class*="accent-warning"]
+  ) {
+    forced-color-adjust: none;
+    background-color: Canvas !important;
+    border-color: CanvasText !important;
+    border-style: dashed !important;
+    border-width: 2px !important;
+    color: CanvasText !important;
+  }
+
+  :where(
+    [class*="bg-blue-"],
+    [class*="text-blue-"],
+    [class*="border-blue-"],
+    [class*="bg-sky-"],
+    [class*="text-sky-"],
+    [class*="border-sky-"],
+    [class*="accent-primary"],
+    [class*="accent-sky"]
+  ) {
+    forced-color-adjust: none;
+    background-color: ButtonFace !important;
+    border-color: LinkText !important;
+    border-style: solid !important;
+    border-width: 1px !important;
+    color: LinkText !important;
+  }
+
+  :where([disabled], [aria-disabled="true"], .disabled) {
+    color: GrayText !important;
+    border-color: GrayText !important;
+  }
+}

--- a/docs/accessibility/forced-colors.md
+++ b/docs/accessibility/forced-colors.md
@@ -1,0 +1,44 @@
+# Forced-colors accessibility notes
+
+This app supports Windows High Contrast and browsers that expose
+`forced-colors: active`.
+
+## Findings
+
+- Many interactive surfaces use Tailwind color utilities such as green, red,
+  amber, blue, sky, and semantic accent classes.
+- In forced-colors mode those custom colors can be overridden by the browser,
+  which can make status badges, toggles, and focus rings lose contrast or lose
+  their visual distinction.
+- Key affected components include buttons, role-button cards, switch controls,
+  pressed filter chips, signal direction badges, warning/error states, and
+  provider/trust badges.
+
+## Fix pattern
+
+Global forced-colors rules live in `app/globals.css` under
+`@media (forced-colors: active)`.
+
+- Interactive controls use system colors such as `ButtonFace`, `ButtonText`,
+  `Highlight`, and `HighlightText`.
+- Focus indicators use an explicit `Highlight` outline so keyboard focus stays
+  visible even when box shadows are removed.
+- Pressed buttons and enabled switches map to `Highlight` / `HighlightText`.
+- Status badges keep meaning without relying only on color:
+  - success / BUY states use a solid border
+  - danger / SELL states use a double border
+  - warning states use a dashed border
+- Blue / informational controls map to `LinkText` on `ButtonFace`.
+
+## Guidance for new components
+
+For new components, prefer semantic class names and ARIA state attributes
+before adding one-off colors:
+
+- use `aria-pressed` for toggle buttons
+- use `role="switch"` with `aria-checked` for switches
+- preserve a visible `:focus-visible` state
+- do not rely on color alone for status badges; pair color with text, icon, or
+  border style
+- test new components with `forced-colors: active` browser emulation before
+  shipping

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "verify:forced-colors": "node scripts/verify-forced-colors.mjs",
     "test": "jest --no-coverage"
   },
   "dependencies": {

--- a/scripts/verify-forced-colors.mjs
+++ b/scripts/verify-forced-colors.mjs
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from "node:fs";
+
+const css = readFileSync("app/globals.css", "utf8");
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const docsPath = "docs/accessibility/forced-colors.md";
+const docs = existsSync(docsPath) ? readFileSync(docsPath, "utf8") : "";
+
+const failures = [];
+
+const requiredCssSnippets = [
+  "@media (forced-colors: active)",
+  "forced-color-adjust",
+  "Canvas",
+  "CanvasText",
+  "ButtonFace",
+  "ButtonText",
+  "Highlight",
+  "HighlightText",
+  ":focus-visible",
+  "[aria-pressed=\"true\"]",
+  "[role=\"switch\"][aria-checked=\"true\"]",
+  "border-style: double",
+  "border-style: dashed",
+];
+
+for (const snippet of requiredCssSnippets) {
+  if (!css.includes(snippet)) {
+    failures.push(`Missing forced-colors CSS snippet: ${snippet}`);
+  }
+}
+
+if (!packageJson.scripts?.["verify:forced-colors"]) {
+  failures.push("Missing verify:forced-colors npm script");
+}
+
+const requiredDocSnippets = [
+  "forced-colors",
+  "Windows High Contrast",
+  "Focus indicators",
+  "status badges",
+  "new components",
+];
+
+for (const snippet of requiredDocSnippets) {
+  if (!docs.includes(snippet)) {
+    failures.push(`Missing forced-colors documentation snippet: ${snippet}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}
+
+console.log("Forced-colors support verified.");


### PR DESCRIPTION
## Summary
- add a global forced-colors media query for Windows High Contrast/browser forced-colors mode
- preserve visible focus outlines for interactive controls using system colors
- map pressed buttons and enabled switches to `Highlight` / `HighlightText`
- keep status badges distinguishable without relying only on color by using solid, double, and dashed border styles
- document the forced-colors pattern for future components

## Validation
- `npm run verify:forced-colors`
- `node --check scripts/verify-forced-colors.mjs`
- `git diff --check`
- `npm run build -- --no-lint` reached the type-check phase after compiling CSS/Tailwind, then stopped on the existing `components/CTABanner.tsx` Framer `Variants` type error

## Existing baseline blockers
- `npm run build -- --no-lint` still fails on the pre-existing `components/CTABanner.tsx` Framer `Variants` type error.
- `npm run lint` still fails on existing conditional hook usage in `components/SignalCard.tsx` and an existing `SignalRecommendations.tsx` dependency warning. This PR does not change those TSX files.
