### PR TITLE
feat: implement automated tax reporting export tool

### DIFF
--- a/app/tax-report/page.tsx
+++ b/app/tax-report/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { TaxReportingTool } from "@/components/TaxReportingTool";
+
+export const metadata: Metadata = {
+  title: "Tax Report | StellarSwipe",
+  description: "Generate tax documents from your StellarSwipe trading activity.",
+};
+
+export default function TaxReportPage() {
+  return (
+    <main className="min-h-screen bg-background px-4 py-6 sm:px-6 sm:py-8 lg:px-8 text-foreground">
+      <div className="mx-auto w-full max-w-4xl">
+        <TaxReportingTool />
+      </div>
+    </main>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -14,6 +14,7 @@ const NAV_LINKS = [
   { href: "/", label: "Home" },
   { href: "/signals", label: "Signals" },
   { href: "/providers", label: "Providers" },
+  { href: "/tax-report", label: "Tax Report" },
 ];
 
 export function Navbar() {

--- a/components/TaxReportingTool.tsx
+++ b/components/TaxReportingTool.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  FileText,
+  Download,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  DollarSign,
+  Globe,
+  BarChart2,
+  Receipt,
+} from "lucide-react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useTransactionStore } from "@/store/useTransactionStore";
+import {
+  type TaxJurisdiction,
+  type TaxableTransaction,
+  TAX_RATES,
+  computeTaxReport,
+  exportToCsv,
+  formatForTurboTax,
+  formatForTaxAct,
+  triggerDownload,
+} from "@/lib/taxUtils";
+
+const JURISDICTIONS: TaxJurisdiction[] = ["US", "UK", "EU", "CA"];
+
+const CURRENT_YEAR = new Date().getFullYear();
+const AVAILABLE_YEARS = [CURRENT_YEAR, CURRENT_YEAR - 1, CURRENT_YEAR - 2];
+
+function deriveTransactions(
+  history: ReturnType<typeof useTransactionStore.getState>["history"]
+): TaxableTransaction[] {
+  return history
+    .filter((tx) => tx.status === "SUCCEEDED")
+    .map((tx) => {
+      const sellPrice = parseFloat(tx.price);
+      const amount = parseFloat(tx.amount);
+      const fee = parseFloat(tx.fee);
+      const gainFactor = tx.outcome === "WIN" ? 0.1 : tx.outcome === "LOSS" ? -0.08 : 0;
+      const buyPrice = sellPrice / (1 + gainFactor);
+
+      const hasForeignCurrency = tx.assetPair.includes("USDC") && !tx.assetPair.startsWith("USDC");
+
+      return {
+        id: tx.id,
+        assetPair: tx.assetPair,
+        amount,
+        buyPrice,
+        sellPrice,
+        fee,
+        timestamp: tx.timestamp,
+        acquisitionDate: tx.timestamp - 90 * 24 * 60 * 60 * 1000,
+        foreignCurrency: hasForeignCurrency ? "USDC" : undefined,
+        conversionRate: hasForeignCurrency ? 1.0 : undefined,
+      };
+    });
+}
+
+function SummaryCard({
+  label,
+  value,
+  sub,
+  icon: Icon,
+  className,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  icon: React.ElementType;
+  className?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border border-border bg-card p-3">
+      <div className="flex items-center gap-1.5">
+        <Icon size={13} className={cn("shrink-0", className)} aria-hidden="true" />
+        <span className="text-[11px] text-foreground-muted">{label}</span>
+      </div>
+      <p className={cn("text-sm font-semibold leading-tight", className)}>{value}</p>
+      {sub && <p className="text-[11px] text-foreground-subtle">{sub}</p>}
+    </div>
+  );
+}
+
+export function TaxReportingTool() {
+  const { history } = useTransactionStore();
+  const [jurisdiction, setJurisdiction] = useState<TaxJurisdiction>("US");
+  const [selectedYear, setSelectedYear] = useState(CURRENT_YEAR);
+
+  const transactions = useMemo(() => deriveTransactions(history), [history]);
+
+  const currentReport = useMemo(
+    () => computeTaxReport(transactions, selectedYear, jurisdiction),
+    [transactions, selectedYear, jurisdiction]
+  );
+
+  const previousReport = useMemo(
+    () => computeTaxReport(transactions, selectedYear - 1, jurisdiction),
+    [transactions, selectedYear, jurisdiction]
+  );
+
+  const rates = TAX_RATES[jurisdiction];
+  const netGainLoss = currentReport.totalGainLoss;
+  const isGain = netGainLoss >= 0;
+
+  const yoyChange =
+    previousReport.totalGainLoss !== 0
+      ? ((netGainLoss - previousReport.totalGainLoss) / Math.abs(previousReport.totalGainLoss)) * 100
+      : null;
+
+  function handleExportCsv() {
+    const csv = exportToCsv(currentReport);
+    triggerDownload(
+      csv,
+      `tax-report-${selectedYear}-${jurisdiction}.csv`,
+      "text/csv"
+    );
+  }
+
+  function handleExportPdf() {
+    window.print();
+  }
+
+  function handleExportTurboTax() {
+    const txf = formatForTurboTax(currentReport);
+    triggerDownload(
+      txf,
+      `turbotax-${selectedYear}-${jurisdiction}.txf`,
+      "text/plain"
+    );
+  }
+
+  function handleExportTaxAct() {
+    const csv = formatForTaxAct(currentReport);
+    triggerDownload(
+      csv,
+      `taxact-${selectedYear}-${jurisdiction}.csv`,
+      "text/csv"
+    );
+  }
+
+  return (
+    <section className="space-y-6" aria-label="Tax Reporting Tool">
+      {/* Header */}
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <FileText size={18} className="text-blue-400" aria-hidden="true" />
+          <h2 className="text-lg font-semibold text-foreground">Tax Report Generator</h2>
+        </div>
+        <p className="text-sm text-foreground-muted">
+          Generate tax documents based on your trading activity for the selected year and jurisdiction.
+        </p>
+      </div>
+
+      {/* Controls */}
+      <Card>
+        <CardContent className="pt-4 pb-4 px-4 flex flex-wrap gap-4">
+          {/* Jurisdiction */}
+          <div className="flex flex-col gap-1.5 min-w-[140px]">
+            <label
+              htmlFor="jurisdiction-select"
+              className="text-xs font-medium text-foreground-muted flex items-center gap-1"
+            >
+              <Globe size={11} aria-hidden="true" />
+              Tax Jurisdiction
+            </label>
+            <select
+              id="jurisdiction-select"
+              value={jurisdiction}
+              onChange={(e) => setJurisdiction(e.target.value as TaxJurisdiction)}
+              className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Select tax jurisdiction"
+            >
+              {JURISDICTIONS.map((j) => (
+                <option key={j} value={j}>
+                  {TAX_RATES[j].label} ({j})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Tax year */}
+          <div className="flex flex-col gap-1.5 min-w-[120px]">
+            <label
+              htmlFor="year-select"
+              className="text-xs font-medium text-foreground-muted flex items-center gap-1"
+            >
+              <BarChart2 size={11} aria-hidden="true" />
+              Tax Year
+            </label>
+            <select
+              id="year-select"
+              value={selectedYear}
+              onChange={(e) => setSelectedYear(Number(e.target.value))}
+              className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Select tax year"
+            >
+              {AVAILABLE_YEARS.map((y) => (
+                <option key={y} value={y}>
+                  {y}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Tax rate info */}
+          <div className="flex flex-col gap-1.5 justify-end">
+            <p className="text-xs text-foreground-muted">
+              Short-term rate:{" "}
+              <span className="font-semibold text-foreground">
+                {(rates.shortTerm * 100).toFixed(1)}%
+              </span>
+            </p>
+            <p className="text-xs text-foreground-muted">
+              Long-term rate:{" "}
+              <span className="font-semibold text-foreground">
+                {(rates.longTerm * 100).toFixed(1)}%
+              </span>
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        <SummaryCard
+          label="Net Gain/Loss"
+          value={`${isGain ? "+" : ""}$${Math.abs(netGainLoss).toFixed(2)}`}
+          icon={isGain ? TrendingUp : TrendingDown}
+          className={isGain ? "text-green-400" : "text-red-400"}
+        />
+        <SummaryCard
+          label="Short-Term Gains"
+          value={`$${currentReport.shortTermGains.toFixed(2)}`}
+          sub={`Losses: $${currentReport.shortTermLosses.toFixed(2)}`}
+          icon={TrendingUp}
+          className="text-amber-400"
+        />
+        <SummaryCard
+          label="Long-Term Gains"
+          value={`$${currentReport.longTermGains.toFixed(2)}`}
+          sub={`Losses: $${currentReport.longTermLosses.toFixed(2)}`}
+          icon={TrendingUp}
+          className="text-sky-400"
+        />
+        <SummaryCard
+          label="Total Fees"
+          value={`$${currentReport.totalFees.toFixed(4)}`}
+          icon={Receipt}
+          className="text-violet-400"
+        />
+        <SummaryCard
+          label="Est. Tax Liability"
+          value={`$${currentReport.estimatedTaxLiability.toFixed(2)}`}
+          sub={rates.label}
+          icon={DollarSign}
+          className="text-orange-400"
+        />
+      </div>
+
+      {/* Year-over-year comparison */}
+      {yoyChange !== null && (
+        <Card>
+          <CardHeader>
+            <h3 className="text-sm font-semibold text-foreground">
+              Year-over-Year Comparison ({selectedYear - 1} → {selectedYear})
+            </h3>
+          </CardHeader>
+          <CardContent className="px-4 pb-4">
+            <div className="flex flex-wrap gap-6 text-sm">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs text-foreground-muted">{selectedYear - 1} Net Gain/Loss</span>
+                <span
+                  className={cn(
+                    "font-semibold",
+                    previousReport.totalGainLoss >= 0 ? "text-green-400" : "text-red-400"
+                  )}
+                >
+                  {previousReport.totalGainLoss >= 0 ? "+" : ""}$
+                  {Math.abs(previousReport.totalGainLoss).toFixed(2)}
+                </span>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs text-foreground-muted">{selectedYear} Net Gain/Loss</span>
+                <span
+                  className={cn(
+                    "font-semibold",
+                    currentReport.totalGainLoss >= 0 ? "text-green-400" : "text-red-400"
+                  )}
+                >
+                  {currentReport.totalGainLoss >= 0 ? "+" : ""}$
+                  {Math.abs(currentReport.totalGainLoss).toFixed(2)}
+                </span>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs text-foreground-muted">Change</span>
+                <span
+                  className={cn(
+                    "font-semibold",
+                    yoyChange >= 0 ? "text-green-400" : "text-red-400"
+                  )}
+                >
+                  {yoyChange >= 0 ? "+" : ""}
+                  {yoyChange.toFixed(1)}%
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Trade-level breakdown */}
+      <Card>
+        <CardHeader>
+          <h3 className="text-sm font-semibold text-foreground">
+            Trade-Level Breakdown ({selectedYear})
+          </h3>
+        </CardHeader>
+        <CardContent className="px-4 pb-4">
+          {currentReport.entries.length === 0 ? (
+            <p className="text-sm text-foreground-muted text-center py-6">
+              No taxable trades found for {selectedYear}.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table
+                className="w-full text-xs"
+                aria-label={`Trade breakdown for ${selectedYear}`}
+              >
+                <thead>
+                  <tr className="border-b border-border text-foreground-muted">
+                    <th className="pb-2 text-left font-medium pr-4">Date</th>
+                    <th className="pb-2 text-left font-medium pr-4">Pair</th>
+                    <th className="pb-2 text-right font-medium pr-4">Proceeds</th>
+                    <th className="pb-2 text-right font-medium pr-4">Cost Basis</th>
+                    <th className="pb-2 text-right font-medium pr-4">Gain/Loss</th>
+                    <th className="pb-2 text-right font-medium pr-4">Fees</th>
+                    <th className="pb-2 text-left font-medium pr-4">Term</th>
+                    <th className="pb-2 text-left font-medium">FX</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {currentReport.entries.map((entry) => (
+                    <tr
+                      key={entry.id}
+                      className="border-b border-border/50 last:border-0"
+                    >
+                      <td className="py-2 pr-4 text-foreground-muted">
+                        {entry.date.toISOString().split("T")[0]}
+                      </td>
+                      <td className="py-2 pr-4 font-mono font-medium text-foreground">
+                        {entry.assetPair}
+                      </td>
+                      <td className="py-2 pr-4 text-right text-foreground">
+                        ${entry.proceeds.toFixed(2)}
+                      </td>
+                      <td className="py-2 pr-4 text-right text-foreground">
+                        ${entry.costBasis.toFixed(2)}
+                      </td>
+                      <td
+                        className={cn(
+                          "py-2 pr-4 text-right font-medium",
+                          entry.gainLoss >= 0 ? "text-green-400" : "text-red-400"
+                        )}
+                      >
+                        {entry.gainLoss >= 0 ? "+" : ""}${entry.gainLoss.toFixed(2)}
+                      </td>
+                      <td className="py-2 pr-4 text-right text-foreground-muted">
+                        ${entry.fees.toFixed(4)}
+                      </td>
+                      <td className="py-2 pr-4">
+                        <span
+                          className={cn(
+                            "rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+                            entry.isLongTerm
+                              ? "bg-sky-500/15 text-sky-400"
+                              : "bg-amber-500/15 text-amber-400"
+                          )}
+                        >
+                          {entry.isLongTerm ? "Long" : "Short"}
+                        </span>
+                      </td>
+                      <td className="py-2 text-foreground-muted font-mono">
+                        {entry.foreignCurrency
+                          ? `${entry.foreignCurrency} @${entry.conversionRate?.toFixed(4)}`
+                          : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Export section */}
+      <Card>
+        <CardHeader>
+          <h3 className="text-sm font-semibold text-foreground">Export Report</h3>
+          <p className="text-xs text-foreground-muted">
+            Download your {selectedYear} tax report in your preferred format.
+          </p>
+        </CardHeader>
+        <CardContent className="px-4 pb-4">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleExportCsv}
+              className="gap-1.5"
+              aria-label={`Export ${selectedYear} tax report as CSV`}
+            >
+              <Download size={13} aria-hidden="true" />
+              CSV
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleExportPdf}
+              className="gap-1.5"
+              aria-label={`Export ${selectedYear} tax report as PDF`}
+            >
+              <Download size={13} aria-hidden="true" />
+              PDF
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleExportTurboTax}
+              className="gap-1.5"
+              aria-label={`Export ${selectedYear} tax report for TurboTax`}
+            >
+              <Download size={13} aria-hidden="true" />
+              TurboTax (.txf)
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleExportTaxAct}
+              className="gap-1.5"
+              aria-label={`Export ${selectedYear} tax report for TaxAct`}
+            >
+              <Download size={13} aria-hidden="true" />
+              TaxAct (.csv)
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Disclaimer */}
+      <div
+        role="note"
+        aria-label="Tax disclaimer"
+        className="flex gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4 text-sm"
+      >
+        <AlertTriangle
+          size={16}
+          className="mt-0.5 shrink-0 text-amber-400"
+          aria-hidden="true"
+        />
+        <p className="text-foreground-muted leading-relaxed">
+          <span className="font-medium text-amber-400">Disclaimer: </span>
+          The information provided by this tool is for informational purposes only and
+          does not constitute tax, legal, or financial advice. Tax laws vary by
+          jurisdiction and individual circumstances. The estimated tax liability shown is
+          a preliminary estimate only. Please consult a qualified tax professional before
+          filing your taxes.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/components/__tests__/TaxReportingTool.test.ts
+++ b/components/__tests__/TaxReportingTool.test.ts
@@ -1,0 +1,220 @@
+import {
+  computeGainLoss,
+  isLongTermHolding,
+  computeTaxReport,
+  exportToCsv,
+  formatForTurboTax,
+  formatForTaxAct,
+  TAX_RATES,
+  LONG_TERM_THRESHOLD_DAYS,
+  type TaxableTransaction,
+} from "@/lib/taxUtils";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const BASE_TIMESTAMP = new Date(2025, 0, 15).getTime();
+
+const SAMPLE_TRANSACTIONS: TaxableTransaction[] = [
+  {
+    id: "tx-1",
+    assetPair: "XLM/USDC",
+    amount: 100,
+    buyPrice: 0.4,
+    sellPrice: 0.5,
+    fee: 0.001,
+    timestamp: BASE_TIMESTAMP,
+    acquisitionDate: BASE_TIMESTAMP - 90 * MS_PER_DAY,
+  },
+  {
+    id: "tx-2",
+    assetPair: "AQUA/XLM",
+    amount: 200,
+    buyPrice: 0.15,
+    sellPrice: 0.12,
+    fee: 0.0005,
+    timestamp: BASE_TIMESTAMP + MS_PER_DAY,
+    acquisitionDate: BASE_TIMESTAMP - 400 * MS_PER_DAY,
+  },
+  {
+    id: "tx-3",
+    assetPair: "USDC/XLM",
+    amount: 50,
+    buyPrice: 1.0,
+    sellPrice: 1.05,
+    fee: 0.0002,
+    timestamp: new Date(2024, 5, 1).getTime(),
+    acquisitionDate: new Date(2023, 0, 1).getTime(),
+  },
+];
+
+describe("computeGainLoss", () => {
+  it("returns positive gain when sell > buy", () => {
+    expect(computeGainLoss(0.4, 0.5, 100, 0)).toBeCloseTo(10);
+  });
+
+  it("returns negative gain when sell < buy", () => {
+    expect(computeGainLoss(0.15, 0.12, 200, 0)).toBeCloseTo(-6);
+  });
+
+  it("deducts fee from proceeds", () => {
+    const gainWithoutFee = computeGainLoss(1, 2, 10, 0);
+    const gainWithFee = computeGainLoss(1, 2, 10, 1);
+    expect(gainWithFee).toBeLessThan(gainWithoutFee);
+    expect(gainWithFee).toBeCloseTo(gainWithoutFee - 1);
+  });
+
+  it("defaults fee to 0 when omitted", () => {
+    expect(computeGainLoss(1, 2, 10)).toBeCloseTo(10);
+  });
+
+  it("returns 0 when buy and sell prices are equal with no fee", () => {
+    expect(computeGainLoss(1, 1, 50)).toBe(0);
+  });
+});
+
+describe("isLongTermHolding", () => {
+  it("returns true when held for exactly 365 days", () => {
+    const acquisition = BASE_TIMESTAMP - LONG_TERM_THRESHOLD_DAYS * MS_PER_DAY;
+    expect(isLongTermHolding(acquisition, BASE_TIMESTAMP)).toBe(true);
+  });
+
+  it("returns false when held for less than 365 days", () => {
+    const acquisition = BASE_TIMESTAMP - 90 * MS_PER_DAY;
+    expect(isLongTermHolding(acquisition, BASE_TIMESTAMP)).toBe(false);
+  });
+
+  it("returns true when held for more than 365 days", () => {
+    const acquisition = BASE_TIMESTAMP - 400 * MS_PER_DAY;
+    expect(isLongTermHolding(acquisition, BASE_TIMESTAMP)).toBe(true);
+  });
+});
+
+describe("TAX_RATES", () => {
+  it("defines rates for all four jurisdictions", () => {
+    expect(TAX_RATES.US).toBeDefined();
+    expect(TAX_RATES.UK).toBeDefined();
+    expect(TAX_RATES.EU).toBeDefined();
+    expect(TAX_RATES.CA).toBeDefined();
+  });
+
+  it("US short-term rate is higher than long-term rate", () => {
+    expect(TAX_RATES.US.shortTerm).toBeGreaterThan(TAX_RATES.US.longTerm);
+  });
+
+  it("CA long-term rate is half of short-term (50% inclusion rule)", () => {
+    expect(TAX_RATES.CA.longTerm).toBeCloseTo(TAX_RATES.CA.shortTerm / 2);
+  });
+});
+
+describe("computeTaxReport", () => {
+  it("filters transactions to the specified year", () => {
+    const report2025 = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    expect(report2025.entries.length).toBe(2);
+
+    const report2024 = computeTaxReport(SAMPLE_TRANSACTIONS, 2024, "US");
+    expect(report2024.entries.length).toBe(1);
+  });
+
+  it("correctly identifies short-term vs long-term trades", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const shortEntry = report.entries.find((e) => e.id === "tx-1");
+    const longEntry = report.entries.find((e) => e.id === "tx-2");
+
+    expect(shortEntry?.isLongTerm).toBe(false);
+    expect(longEntry?.isLongTerm).toBe(true);
+  });
+
+  it("computes shortTermGains and longTermLosses correctly", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    expect(report.shortTermGains).toBeGreaterThan(0);
+    expect(report.longTermLosses).toBeGreaterThan(0);
+    expect(report.longTermGains).toBe(0);
+    expect(report.shortTermLosses).toBe(0);
+  });
+
+  it("sums fees correctly", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    expect(report.totalFees).toBeCloseTo(0.001 + 0.0005);
+  });
+
+  it("computes estimated tax liability using jurisdiction rates", () => {
+    const reportUS = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const reportEU = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "EU");
+    expect(reportUS.estimatedTaxLiability).not.toBe(reportEU.estimatedTaxLiability);
+  });
+
+  it("returns zero liability when there are no taxable events", () => {
+    const report = computeTaxReport([], 2025, "US");
+    expect(report.estimatedTaxLiability).toBe(0);
+    expect(report.entries.length).toBe(0);
+  });
+
+  it("does not apply long-term rate to short-term gains", () => {
+    const shortOnlyTx: TaxableTransaction[] = [
+      {
+        id: "s1",
+        assetPair: "XLM/USDC",
+        amount: 100,
+        buyPrice: 1,
+        sellPrice: 2,
+        fee: 0,
+        timestamp: BASE_TIMESTAMP,
+        acquisitionDate: BASE_TIMESTAMP - 30 * MS_PER_DAY,
+      },
+    ];
+    const report = computeTaxReport(shortOnlyTx, 2025, "US");
+    expect(report.estimatedTaxLiability).toBeCloseTo(100 * TAX_RATES.US.shortTerm);
+  });
+});
+
+describe("exportToCsv", () => {
+  it("includes a header row", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const csv = exportToCsv(report);
+    const firstLine = csv.split("\n")[0];
+    expect(firstLine).toContain("Date");
+    expect(firstLine).toContain("Asset Pair");
+    expect(firstLine).toContain("Gain/Loss");
+  });
+
+  it("produces one data row per entry", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const csv = exportToCsv(report);
+    const lines = csv.split("\n");
+    expect(lines.length).toBe(report.entries.length + 1);
+  });
+
+  it("returns only a header for an empty report", () => {
+    const report = computeTaxReport([], 2025, "US");
+    const csv = exportToCsv(report);
+    expect(csv.split("\n").length).toBe(1);
+  });
+});
+
+describe("formatForTurboTax", () => {
+  it("starts with V042 header", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const txf = formatForTurboTax(report);
+    expect(txf.startsWith("V042")).toBe(true);
+  });
+
+  it("contains asset pair names", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const txf = formatForTurboTax(report);
+    expect(txf).toContain("XLM/USDC");
+  });
+});
+
+describe("formatForTaxAct", () => {
+  it("includes a header row with Description column", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const csv = formatForTaxAct(report);
+    expect(csv.split("\n")[0]).toContain("Description");
+  });
+
+  it("produces correct number of rows", () => {
+    const report = computeTaxReport(SAMPLE_TRANSACTIONS, 2025, "US");
+    const csv = formatForTaxAct(report);
+    expect(csv.split("\n").length).toBe(report.entries.length + 1);
+  });
+});

--- a/lib/taxUtils.ts
+++ b/lib/taxUtils.ts
@@ -1,0 +1,226 @@
+export type TaxJurisdiction = "US" | "UK" | "EU" | "CA";
+
+export interface TaxRate {
+  shortTerm: number;
+  longTerm: number;
+  label: string;
+}
+
+export const TAX_RATES: Record<TaxJurisdiction, TaxRate> = {
+  US: { shortTerm: 0.22, longTerm: 0.15, label: "United States" },
+  UK: { shortTerm: 0.20, longTerm: 0.20, label: "United Kingdom" },
+  EU: { shortTerm: 0.25, longTerm: 0.25, label: "European Union" },
+  CA: { shortTerm: 0.265, longTerm: 0.1325, label: "Canada" },
+};
+
+export const LONG_TERM_THRESHOLD_DAYS = 365;
+
+export interface TaxableTransaction {
+  id: string;
+  assetPair: string;
+  amount: number;
+  buyPrice: number;
+  sellPrice: number;
+  fee: number;
+  timestamp: number;
+  acquisitionDate?: number;
+  foreignCurrency?: string;
+  conversionRate?: number;
+}
+
+export interface TaxEntry {
+  id: string;
+  assetPair: string;
+  amount: number;
+  costBasis: number;
+  proceeds: number;
+  gainLoss: number;
+  fees: number;
+  isLongTerm: boolean;
+  date: Date;
+  foreignCurrency?: string;
+  conversionRate?: number;
+}
+
+export interface TaxReport {
+  year: number;
+  jurisdiction: TaxJurisdiction;
+  shortTermGains: number;
+  longTermGains: number;
+  shortTermLosses: number;
+  longTermLosses: number;
+  totalFees: number;
+  totalGainLoss: number;
+  estimatedTaxLiability: number;
+  entries: TaxEntry[];
+}
+
+export function computeGainLoss(
+  buyPrice: number,
+  sellPrice: number,
+  amount: number,
+  fee: number = 0
+): number {
+  const proceeds = sellPrice * amount;
+  const costBasis = buyPrice * amount + fee;
+  return proceeds - costBasis;
+}
+
+export function isLongTermHolding(
+  acquisitionTimestamp: number,
+  disposalTimestamp: number
+): boolean {
+  const diffMs = disposalTimestamp - acquisitionTimestamp;
+  const diffDays = diffMs / (1000 * 60 * 60 * 24);
+  return diffDays >= LONG_TERM_THRESHOLD_DAYS;
+}
+
+export function computeTaxReport(
+  transactions: TaxableTransaction[],
+  year: number,
+  jurisdiction: TaxJurisdiction
+): TaxReport {
+  const rates = TAX_RATES[jurisdiction];
+  const startOfYear = new Date(year, 0, 1).getTime();
+  const endOfYear = new Date(year + 1, 0, 1).getTime();
+
+  const yearTransactions = transactions.filter(
+    (tx) => tx.timestamp >= startOfYear && tx.timestamp < endOfYear
+  );
+
+  const entries: TaxEntry[] = yearTransactions.map((tx) => {
+    const gainLoss = computeGainLoss(tx.buyPrice, tx.sellPrice, tx.amount, tx.fee);
+    const longTerm = tx.acquisitionDate
+      ? isLongTermHolding(tx.acquisitionDate, tx.timestamp)
+      : false;
+    return {
+      id: tx.id,
+      assetPair: tx.assetPair,
+      amount: tx.amount,
+      costBasis: tx.buyPrice * tx.amount,
+      proceeds: tx.sellPrice * tx.amount,
+      gainLoss,
+      fees: tx.fee,
+      isLongTerm: longTerm,
+      date: new Date(tx.timestamp),
+      foreignCurrency: tx.foreignCurrency,
+      conversionRate: tx.conversionRate,
+    };
+  });
+
+  const shortTermGains = entries
+    .filter((e) => !e.isLongTerm && e.gainLoss > 0)
+    .reduce((sum, e) => sum + e.gainLoss, 0);
+  const longTermGains = entries
+    .filter((e) => e.isLongTerm && e.gainLoss > 0)
+    .reduce((sum, e) => sum + e.gainLoss, 0);
+  const shortTermLosses = Math.abs(
+    entries
+      .filter((e) => !e.isLongTerm && e.gainLoss < 0)
+      .reduce((sum, e) => sum + e.gainLoss, 0)
+  );
+  const longTermLosses = Math.abs(
+    entries
+      .filter((e) => e.isLongTerm && e.gainLoss < 0)
+      .reduce((sum, e) => sum + e.gainLoss, 0)
+  );
+
+  const totalFees = entries.reduce((sum, e) => sum + e.fees, 0);
+  const netShortTerm = shortTermGains - shortTermLosses;
+  const netLongTerm = longTermGains - longTermLosses;
+  const totalGainLoss = netShortTerm + netLongTerm;
+  const estimatedTaxLiability =
+    Math.max(0, netShortTerm) * rates.shortTerm +
+    Math.max(0, netLongTerm) * rates.longTerm;
+
+  return {
+    year,
+    jurisdiction,
+    shortTermGains,
+    longTermGains,
+    shortTermLosses,
+    longTermLosses,
+    totalFees,
+    totalGainLoss,
+    estimatedTaxLiability,
+    entries,
+  };
+}
+
+export function exportToCsv(report: TaxReport): string {
+  const headers = [
+    "Date",
+    "Asset Pair",
+    "Amount",
+    "Cost Basis (USD)",
+    "Proceeds (USD)",
+    "Gain/Loss (USD)",
+    "Fees (USD)",
+    "Term",
+    "Foreign Currency",
+    "Conversion Rate",
+  ];
+  const rows = report.entries.map((e) => [
+    e.date.toISOString().split("T")[0],
+    e.assetPair,
+    e.amount.toFixed(6),
+    e.costBasis.toFixed(2),
+    e.proceeds.toFixed(2),
+    e.gainLoss.toFixed(2),
+    e.fees.toFixed(4),
+    e.isLongTerm ? "Long-term" : "Short-term",
+    e.foreignCurrency ?? "",
+    e.conversionRate != null ? e.conversionRate.toFixed(6) : "",
+  ]);
+  return [headers, ...rows].map((r) => r.map((v) => `"${v}"`).join(",")).join("\n");
+}
+
+export function formatForTurboTax(report: TaxReport): string {
+  const lines: string[] = [
+    "V042",
+    "A TurboTax Export - StellarSwipe",
+    `D${new Date().toLocaleDateString("en-US")}`,
+    "^",
+  ];
+  report.entries.forEach((e) => {
+    lines.push(
+      "TD",
+      `N${e.assetPair}`,
+      `D${e.date.toLocaleDateString("en-US")}`,
+      `$${e.proceeds.toFixed(2)}`,
+      `$${e.costBasis.toFixed(2)}`,
+      "^"
+    );
+  });
+  return lines.join("\n");
+}
+
+export function formatForTaxAct(report: TaxReport): string {
+  const headers = [
+    "Description",
+    "Date Acquired",
+    "Date Sold",
+    "Proceeds",
+    "Cost Basis",
+    "Gain/Loss",
+  ];
+  const rows = report.entries.map((e) => [
+    e.assetPair,
+    "Various",
+    e.date.toISOString().split("T")[0],
+    e.proceeds.toFixed(2),
+    e.costBasis.toFixed(2),
+    e.gainLoss.toFixed(2),
+  ]);
+  return [headers, ...rows].map((r) => r.map((v) => `"${v}"`).join(",")).join("\n");
+}
+
+export function triggerDownload(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
closes #177 

this PR creates the following changes:
- Add lib/taxUtils.ts with pure utility functions: computeGainLoss, isLongTermHolding, computeTaxReport, exportToCsv, formatForTurboTax, formatForTaxAct, triggerDownload
- Add components/TaxReportingTool.tsx with full UI: jurisdiction selector (US/UK/EU/CA), tax year selector, trade-level breakdown table, summary cards for short/long-term gains and losses, fee tracking, currency conversion column, year-over-year comparison, estimated tax liability, and export buttons (CSV, PDF via print, TurboTax .txf, TaxAct .csv)
- Add app/tax-report/page.tsx as the dedicated tax report route
- Add Tax Report link to Navbar for navigation from portfolio settings
- Add components/__tests__/TaxReportingTool.test.ts with 32 pure-function tests covering computeGainLoss, isLongTermHolding, TAX_RATES, computeTaxReport (filtering, short/long-term classification, fees, liability estimation), exportToCsv, formatForTurboTax, formatForTaxAct