### PR TITLE
feat(#289): implement responsive design improvements for mobile devices

### DIFF
--- a/components/NavHeader.tsx
+++ b/components/NavHeader.tsx
@@ -2,10 +2,21 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+
+const NAV_LINKS = [
+  { href: "/", label: "Home" },
+  { href: "/app", label: "Signals" },
+  { href: "/compare", label: "Compare" },
+  { href: "/leaderboard", label: "Leaderboard" },
+  { href: "/backtest-sim", label: "Backtest" },
+];
 
 export function NavHeader() {
   const pathname = usePathname();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-sticky border-b border-border bg-background/80 backdrop-blur-md">
@@ -14,27 +25,54 @@ export function NavHeader() {
           StellarSwipe
         </Link>
 
-        <div className="flex items-center gap-4">
-          <Link
-            href="/"
-            className={cn(
-              "text-sm font-medium transition-colors hover:text-accent-primary",
-              pathname === "/" ? "text-accent-primary" : "text-foreground-muted"
-            )}
-          >
-            Home
-          </Link>
-          <Link
-            href="/app"
-            className={cn(
-              "text-sm font-medium transition-colors hover:text-accent-primary",
-              pathname === "/app" ? "text-accent-primary" : "text-foreground-muted"
-            )}
-          >
-            Signals
-          </Link>
+        {/* Desktop nav */}
+        <div className="hidden sm:flex items-center gap-4">
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                "text-sm font-medium transition-colors hover:text-accent-primary",
+                pathname === link.href ? "text-accent-primary" : "text-foreground-muted"
+              )}
+            >
+              {link.label}
+            </Link>
+          ))}
         </div>
+
+        {/* Mobile hamburger button */}
+        <button
+          type="button"
+          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          className="sm:hidden flex h-10 w-10 items-center justify-center rounded-lg text-foreground-muted hover:bg-accent hover:text-foreground transition-colors"
+          aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={mobileMenuOpen}
+        >
+          {mobileMenuOpen ? <X size={22} /> : <Menu size={22} />}
+        </button>
       </div>
+
+      {/* Mobile menu panel */}
+      {mobileMenuOpen && (
+        <div className="sm:hidden border-t border-border bg-background/95 backdrop-blur-md">
+          <div className="flex flex-col px-4 py-2 pb-safe">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setMobileMenuOpen(false)}
+                className={cn(
+                  "flex items-center h-12 text-sm font-medium transition-colors border-b border-border/50 last:border-b-0",
+                  pathname === link.href ? "text-accent-primary" : "text-foreground-muted hover:text-foreground"
+                )}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
     </nav>
   );
 }

--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -400,22 +400,22 @@ export function SignalCard({
               </div>
             </div>
 
-            <div className="grid grid-cols-2 gap-3 text-sm">
+            <div className="grid grid-cols-2 gap-2 gap-y-3 text-xs sm:text-sm sm:gap-3">
               <div>
                 <p className="text-muted-foreground">Execution Price</p>
-                <p className="font-mono font-semibold">{fmt(executionPrice)}</p>
+                <p className="font-mono font-semibold text-sm sm:text-base">{fmt(executionPrice)}</p>
               </div>
               <div>
                 <p className="text-muted-foreground">Confidence</p>
-                <p className="font-semibold">{signalConfidence}%</p>
+                <p className="font-semibold text-sm sm:text-base">{signalConfidence}%</p>
               </div>
               <div>
                 <p className="text-muted-foreground">Target</p>
-                <p className="font-mono font-semibold">{fmt(projectedTarget)}</p>
+                <p className="font-mono font-semibold text-sm sm:text-base">{fmt(projectedTarget)}</p>
               </div>
               <div>
                 <p className="text-muted-foreground">ROI</p>
-                <p className={cn("font-semibold", isPositive ? "text-accent-success" : "text-accent-danger")}>
+                <p className={cn("font-semibold text-sm sm:text-base", isPositive ? "text-accent-success" : "text-accent-danger")}>
                   {isPositive ? "+" : ""}{roi}%
                 </p>
               </div>
@@ -518,19 +518,17 @@ export function SignalCard({
             <div className="flex gap-2 pt-2">
               <Button
                 variant="outline"
-                size="sm"
                 onClick={handlePass}
-                className="flex-1"
+                className="flex-1 h-11 sm:h-9 text-sm sm:text-xs"
                 aria-label={`Pass on ${signalAction} signal for ${signalPair}`}
               >
                 <X size={16} className="mr-1" />
                 Pass
               </Button>
               <Button
-                size="sm"
                 onClick={handleExecuteTrade}
                 disabled={modalOpen || (isPremium && !hasAccess) || !!conflictReason}
-                className="flex-1 active:scale-95"
+                className="flex-1 h-11 sm:h-9 text-sm sm:text-xs active:scale-95"
                 aria-label={`Execute trade: ${signalAction} signal for ${signalPair} at ${executionPrice}${isDemoMode ? " (demo)" : ""}${isPremium && !hasAccess ? " (locked — stake required)" : ""}${conflictReason ? " (unavailable — signal conflict)" : ""}`}
               >
                 <Zap size={16} className="mr-1" />

--- a/components/WalletSelectionModal.tsx
+++ b/components/WalletSelectionModal.tsx
@@ -139,7 +139,7 @@ export function WalletSelectionModal({ open, onClose }: WalletSelectionModalProp
             aria-modal="true"
             aria-labelledby="wallet-modal-title"
             aria-describedby="wallet-modal-description"
-            className="relative z-overlay w-full max-w-sm rounded-2xl border border-border bg-surface/95 p-6 shadow-2xl"
+            className="relative z-overlay w-full max-w-sm rounded-2xl border border-border bg-surface/95 p-6 shadow-2xl mx-4 sm:mx-0"
             initial={{ scale: 0.92, opacity: 0, y: 20 }}
             animate={{ scale: 1, opacity: 1, y: 0 }}
             exit={{ scale: 0.92, opacity: 0, y: 20 }}
@@ -177,7 +177,7 @@ export function WalletSelectionModal({ open, onClose }: WalletSelectionModalProp
                     onClick={() => handleSelectWallet(wallet)}
                     disabled={isConnecting || state === "detecting"}
                     aria-describedby={`wallet-${wallet.id}-description`}
-                    className="w-full flex items-start gap-4 rounded-xl border border-border bg-surface p-4 text-left hover:border-blue-500/50 hover:bg-surface-high/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="w-full flex items-start gap-4 rounded-xl border border-border bg-surface p-4 text-left hover:border-blue-500/50 hover:bg-surface-high/50 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 min-h-[68px]"
                   >
                     {/* Icon */}
                     <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-600/20 border border-blue-500/30">


### PR DESCRIPTION
## Summary
Implements responsive design improvements for mobile devices as specified

## Changes
### SignalCard
- Stats grid: smaller text/gaps on mobile (`text-xs`, `gap-2`), scales up at `sm` breakpoint
- Action buttons: touch-friendly height (`h-11`) on mobile, normal (`h-9`) at `sm`

### NavHeader
- Added hamburger menu (Menu/X icons) for mobile (< `sm` breakpoint)
- Desktop nav hidden on mobile, shown at `sm+`
- Mobile menu panel with full-width touch targets (`h-12` per link)
- Added Compare, Leaderboard, Backtest nav links
- Accessible: `aria-label`, `aria-expanded`, keyboard support

### WalletSelectionModal
- Added horizontal margin (`mx-4`) on mobile to prevent edge-to-edge
- Wallet option buttons: `min-h-[68px]` for touch-friendly targets

### TradeModal
- Already had bottom sheet pattern (fixed `bottom-0`, `rounded-t-2xl`)
- Mobile drag handle already present

Closes #289