### PR TITLE
feat: add anonymous performance monitoring with consent and dashboard

### DIFF
--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { PerformanceDashboard } from "@/components/performance/PerformanceDashboard";
+
+export default function PerformancePage() {
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-foreground sm:text-3xl">
+          Performance Monitoring
+        </h1>
+        <p className="mt-2 text-sm text-foreground-muted">
+          Anonymous metrics for load times, API latency, crashes, device
+          performance, and user experience.
+        </p>
+      </div>
+      <PerformanceDashboard />
+    </main>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/lib/queryClient";
 import { ToastProvider } from "@/components/ui/toast";
 import { initI18n } from "@/lib/i18n";
+import { PerformanceMonitoringProvider } from "@/components/performance/PerformanceMonitoringProvider";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   useEffect(() => {
@@ -14,7 +15,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      {children}
+      <PerformanceMonitoringProvider>
+        {children}
+      </PerformanceMonitoringProvider>
       <ToastProvider />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useLeaderboardStore } from "../store/leaderboardStore";
+import { useLeaderboardStore, type LeaderboardEntry } from "../store/leaderboardStore";
 import { formatNumber } from "../lib/utils";
 
 export const Leaderboard: React.FC = () => {
@@ -27,7 +27,7 @@ export const Leaderboard: React.FC = () => {
         Community Leaderboard
       </h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {rankings.map((entry) => (
+        {rankings.map((entry: LeaderboardEntry) => (
           <article
             key={entry.id}
             className="p-4 bg-white bg-opacity-70 backdrop-filter backdrop-blur-lg rounded-xl shadow hover:shadow-xl transition-shadow"

--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -106,6 +106,7 @@ export function SignalCard({
   const [copiedFeedback, setCopiedFeedback] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [detailsExpanded, setDetailsExpanded] = useState(false);
+  const [actionAnnouncement, setActionAnnouncement] = useState("");
   const shouldReduceMotion = useReducedMotion();
   const { isDemoMode } = useDemoModeStore();
   const fmt = usePriceFormat();
@@ -144,6 +145,37 @@ export function SignalCard({
   const deltaLabel = `${deltaPercent >= 0 ? "+" : ""}${deltaPercent.toFixed(2)}%`;
   const deltaAbsLabel = `${deltaValue >= 0 ? "+" : ""}${deltaValue.toFixed(4)}`;
   const deltaPositive = deltaValue >= 0;
+
+  useEffect(() => {
+    if (!copiedFeedback) return;
+    const timer = window.setTimeout(() => setCopiedFeedback(false), 2000);
+    return () => clearTimeout(timer);
+  }, [copiedFeedback]);
+
+  useEffect(() => {
+    return x.on("change", (latest) => {
+      const abs = Math.abs(latest);
+      if (abs >= SWIPE_THRESHOLD && !hasVibratedRef.current) {
+        hasVibratedRef.current = true;
+        navigator.vibrate?.(8);
+      } else if (abs < SWIPE_THRESHOLD * 0.6) {
+        hasVibratedRef.current = false;
+      }
+    });
+  }, [x]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (shareMenuRef.current && !shareMenuRef.current.contains(event.target as Node)) {
+        setShowShareMenu(false);
+      }
+    }
+
+    if (showShareMenu) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [showShareMenu]);
 
   if (loading) return <TradeSkeleton />;
 
@@ -214,37 +246,6 @@ export function SignalCard({
     }
     setShowShareMenu(false);
   }
-
-  useEffect(() => {
-    if (!copiedFeedback) return;
-    const timer = window.setTimeout(() => setCopiedFeedback(false), 2000);
-    return () => clearTimeout(timer);
-  }, [copiedFeedback]);
-
-  useEffect(() => {
-    return x.on("change", (latest) => {
-      const abs = Math.abs(latest);
-      if (abs >= SWIPE_THRESHOLD && !hasVibratedRef.current) {
-        hasVibratedRef.current = true;
-        navigator.vibrate?.(8);
-      } else if (abs < SWIPE_THRESHOLD * 0.6) {
-        hasVibratedRef.current = false;
-      }
-    });
-  }, [x]);
-
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (shareMenuRef.current && !shareMenuRef.current.contains(event.target as Node)) {
-        setShowShareMenu(false);
-      }
-    }
-
-    if (showShareMenu) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [showShareMenu]);
 
   function handleDragEnd(_: unknown, info: PanInfo) {
     const offsetX = info.offset.x;

--- a/components/TradeModal.tsx
+++ b/components/TradeModal.tsx
@@ -89,14 +89,6 @@ export function TradeModal({
   const exceedsPositionLimit =
     positionLimitEnabled && positionLimitInUSD !== null && total > positionLimitInUSD;
   const hasErrors = !!amountError || (type === "LIMIT" && !!limitPriceError);
-  const disabled =
-    !amount ||
-    (type === "LIMIT" && !limitPrice) ||
-    insufficient ||
-    exceedsPositionLimit ||
-    submitting ||
-    hasErrors ||
-    showSlippageWarning;
 
   // Estimate slippage: market orders use a fixed proxy; limit orders use
   // the deviation between the user's limit price and the current market price.
@@ -109,6 +101,15 @@ export function TradeModal({
   const SLIPPAGE_THRESHOLD = 1; // percent
   const showSlippageWarning =
     estimatedSlippage > SLIPPAGE_THRESHOLD && !slippageAcknowledged && !!amount;
+
+  const disabled =
+    !amount ||
+    (type === "LIMIT" && !limitPrice) ||
+    insufficient ||
+    exceedsPositionLimit ||
+    submitting ||
+    hasErrors ||
+    showSlippageWarning;
 
   // Reset form state when modal opens
   useEffect(() => {
@@ -159,7 +160,7 @@ export function TradeModal({
     setSubmitting(true);
     await mockBuildTx({ type, price, amount, stopLoss, positionLimit });
     setSubmitting(false);
-    onConfirm ? onConfirm() : onClose();
+    onConfirm ? onConfirm({ amount, price, orderType: type }) : onClose();
   }, [type, price, amount, stopLoss, positionLimit, onClose, onConfirm, disabled]);
 
   // Announce order-type changes to screen readers via live region

--- a/components/performance/PerformanceDashboard.tsx
+++ b/components/performance/PerformanceDashboard.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import {
+  Activity,
+  AlertTriangle,
+  Battery,
+  Cpu,
+  Globe,
+  MousePointerClick,
+  Timer,
+  Wifi,
+} from "lucide-react";
+import { usePerformanceMonitoringStore } from "@/store/usePerformanceMonitoringStore";
+import type { NetworkConnectionType } from "@/lib/performance/types";
+
+function formatMs(ms: number): string {
+  return `${ms} ms`;
+}
+
+function avg(values: number[]): number {
+  if (values.length === 0) return 0;
+  return Math.round(values.reduce((a, b) => a + b, 0) / values.length);
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  sub,
+}: {
+  label: string;
+  value: string;
+  icon: React.ComponentType<{ className?: string }>;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-foreground-muted">
+        <Icon className="h-3.5 w-3.5 text-sky-400" aria-hidden="true" />
+        {label}
+      </div>
+      <div className="text-2xl font-bold tabular-nums text-foreground">{value}</div>
+      {sub && <div className="mt-1 text-xs text-foreground-muted">{sub}</div>}
+    </div>
+  );
+}
+
+function NetworkRow({
+  type,
+  count,
+  avgApiMs,
+}: {
+  type: NetworkConnectionType;
+  count: number;
+  avgApiMs: number;
+}) {
+  const label =
+    type === "wifi"
+      ? "WiFi"
+      : type === "cellular"
+      ? "Mobile data"
+      : type.charAt(0).toUpperCase() + type.slice(1);
+
+  return (
+    <div className="flex items-center justify-between rounded-lg bg-white/5 px-3 py-2 text-sm">
+      <span className="text-foreground-muted">{label}</span>
+      <span className="tabular-nums text-foreground">
+        {count} calls · avg {avgApiMs} ms
+      </span>
+    </div>
+  );
+}
+
+function HeatmapCanvas({ points }: { points: { x: number; y: number }[] }) {
+  return (
+    <div
+      className="relative aspect-[9/16] w-full max-w-xs overflow-hidden rounded-xl border border-white/10 bg-slate-900"
+      aria-label="Interaction heatmap"
+    >
+      {points.map((p, i) => (
+        <div
+          key={`${p.x}-${p.y}-${i}`}
+          className="pointer-events-none absolute h-6 w-6 -translate-x-1/2 -translate-y-1/2 rounded-full bg-orange-500/40 blur-sm"
+          style={{ left: `${p.x}%`, top: `${p.y}%` }}
+        />
+      ))}
+      {points.length === 0 && (
+        <div className="flex h-full items-center justify-center text-xs text-foreground-muted">
+          No interactions recorded yet
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PerformanceDashboard() {
+  const consent = usePerformanceMonitoringStore((s) => s.consent);
+  const setConsent = usePerformanceMonitoringStore((s) => s.setConsent);
+  const summary = usePerformanceMonitoringStore((s) => s.getSummary());
+
+  const routeStats = useMemo(() => {
+    const byRoute = new Map<string, number[]>();
+    for (const entry of summary.routeLoads) {
+      const list = byRoute.get(entry.route) ?? [];
+      list.push(entry.loadTimeMs);
+      byRoute.set(entry.route, list);
+    }
+    return Array.from(byRoute.entries()).map(([route, times]) => ({
+      route,
+      avgMs: avg(times),
+      count: times.length,
+    }));
+  }, [summary.routeLoads]);
+
+  const avgApiMs = avg(summary.apiResponses.map((e) => e.durationMs));
+  const latestMemory = summary.memorySamples.at(-1);
+  const latestBattery = summary.batterySamples.at(-1);
+  const device = summary.device;
+
+  if (consent === "pending") {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-8 text-center">
+        <Activity className="mx-auto mb-3 h-8 w-8 text-sky-400" />
+        <h2 className="text-lg font-semibold">Consent required</h2>
+        <p className="mt-2 text-sm text-foreground-muted">
+          Enable anonymous performance monitoring to view metrics on this page.
+        </p>
+        <button
+          type="button"
+          onClick={() => setConsent("granted")}
+          className="mt-4 rounded-xl bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:opacity-90"
+        >
+          Enable monitoring
+        </button>
+      </div>
+    );
+  }
+
+  if (consent === "denied") {
+    return (
+      <div className="rounded-2xl border border-white/10 bg-white/5 p-8 text-center">
+        <h2 className="text-lg font-semibold">Monitoring disabled</h2>
+        <p className="mt-2 text-sm text-foreground-muted">
+          You declined performance monitoring. You can enable it anytime.
+        </p>
+        <button
+          type="button"
+          onClick={() => setConsent("granted")}
+          className="mt-4 rounded-xl bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:opacity-90"
+        >
+          Enable monitoring
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <StatCard
+          label="Avg page load"
+          value={formatMs(avg(summary.routeLoads.map((r) => r.loadTimeMs)))}
+          icon={Timer}
+          sub={`${summary.routeLoads.length} samples`}
+        />
+        <StatCard
+          label="Avg API response"
+          value={formatMs(avgApiMs)}
+          icon={Globe}
+          sub={`${summary.apiResponses.length} requests`}
+        />
+        <StatCard
+          label="Memory usage"
+          value={
+            latestMemory?.usedMb != null
+              ? `${latestMemory.usedMb} MB`
+              : "N/A"
+          }
+          icon={Cpu}
+          sub={
+            latestMemory?.totalMb != null
+              ? `of ${latestMemory.totalMb} MB heap`
+              : "Chrome only"
+          }
+        />
+        <StatCard
+          label="Battery"
+          value={
+            latestBattery?.level != null
+              ? `${latestBattery.level}%`
+              : "N/A"
+          }
+          icon={Battery}
+          sub={
+            latestBattery?.charging != null
+              ? latestBattery.charging
+                ? "Charging"
+                : "On battery"
+              : "API unavailable"
+          }
+        />
+      </div>
+
+      {device && (
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-foreground-muted">
+            <Cpu className="h-4 w-4 text-sky-400" />
+            Device &amp; OS breakdown
+          </h2>
+          <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+            <div>
+              <dt className="text-foreground-muted">OS</dt>
+              <dd className="font-medium">{device.os}</dd>
+            </div>
+            <div>
+              <dt className="text-foreground-muted">Device</dt>
+              <dd className="font-medium capitalize">{device.deviceType}</dd>
+            </div>
+            <div>
+              <dt className="text-foreground-muted">Screen</dt>
+              <dd className="font-medium">
+                {device.screenWidth}×{device.screenHeight}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-foreground-muted">Network</dt>
+              <dd className="font-medium capitalize">{device.networkType}</dd>
+            </div>
+          </dl>
+        </section>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-foreground-muted">
+            <Timer className="h-4 w-4 text-sky-400" />
+            Page load time by route
+          </h2>
+          {routeStats.length === 0 ? (
+            <p className="text-sm text-foreground-muted">No route data yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {routeStats.map((r) => (
+                <li
+                  key={r.route}
+                  className="flex items-center justify-between rounded-lg bg-white/5 px-3 py-2 text-sm"
+                >
+                  <Link href={r.route} className="font-mono text-sky-400 hover:underline">
+                    {r.route}
+                  </Link>
+                  <span className="tabular-nums text-foreground">
+                    {r.avgMs} ms · {r.count}×
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-foreground-muted">
+            <Wifi className="h-4 w-4 text-sky-400" />
+            Network type impact
+          </h2>
+          <div className="space-y-2">
+            {(Object.entries(summary.networkBreakdown) as [
+              NetworkConnectionType,
+              { count: number; avgApiMs: number },
+            ][])
+              .filter(([, v]) => v.count > 0)
+              .map(([type, stats]) => (
+                <NetworkRow
+                  key={type}
+                  type={type}
+                  count={stats.count}
+                  avgApiMs={stats.avgApiMs}
+                />
+              ))}
+            {summary.apiResponses.length === 0 && (
+              <p className="text-sm text-foreground-muted">No API data yet.</p>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-foreground-muted">
+            <MousePointerClick className="h-4 w-4 text-sky-400" />
+            Interaction heatmap
+          </h2>
+          <HeatmapCanvas points={summary.heatmap} />
+        </section>
+
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-foreground-muted">
+            <AlertTriangle className="h-4 w-4 text-red-400" />
+            Crash reports
+          </h2>
+          {summary.crashes.length === 0 ? (
+            <p className="text-sm text-foreground-muted">No crashes recorded.</p>
+          ) : (
+            <ul className="max-h-80 space-y-3 overflow-y-auto">
+              {summary.crashes
+                .slice()
+                .reverse()
+                .map((crash) => (
+                  <li
+                    key={crash.id}
+                    className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-xs"
+                  >
+                    <div className="font-semibold text-red-400">{crash.message}</div>
+                    <div className="mt-1 text-foreground-muted">
+                      {crash.route} · {new Date(crash.timestamp).toLocaleString()}
+                    </div>
+                    {crash.stack && (
+                      <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap text-[10px] text-foreground-muted">
+                        {crash.stack}
+                      </pre>
+                    )}
+                    {crash.sessionSnapshot.length > 0 && (
+                      <details className="mt-2">
+                        <summary className="cursor-pointer text-foreground-muted">
+                          Session recording ({crash.sessionSnapshot.length} events)
+                        </summary>
+                        <ol className="mt-1 list-inside list-decimal space-y-0.5 text-[10px] text-foreground-muted">
+                          {crash.sessionSnapshot.slice(-10).map((e, i) => (
+                            <li key={i}>
+                              [{e.type}] {e.label}
+                            </li>
+                          ))}
+                        </ol>
+                      </details>
+                    )}
+                  </li>
+                ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/performance/PerformanceMonitoringConsent.tsx
+++ b/components/performance/PerformanceMonitoringConsent.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Activity, ShieldCheck, X } from "lucide-react";
+import { usePerformanceMonitoringStore } from "@/store/usePerformanceMonitoringStore";
+
+export function PerformanceMonitoringConsent() {
+  const consent = usePerformanceMonitoringStore((s) => s.consent);
+  const setConsent = usePerformanceMonitoringStore((s) => s.setConsent);
+
+  if (consent !== "pending") return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby="perf-consent-title"
+      aria-describedby="perf-consent-desc"
+      className="fixed bottom-4 left-4 right-4 z-[9998] mx-auto max-w-lg rounded-2xl border border-white/10 bg-slate-950/95 p-4 shadow-2xl shadow-black/50 backdrop-blur-sm sm:left-auto sm:right-4"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-sky-500/20">
+          <Activity className="h-5 w-5 text-sky-400" aria-hidden="true" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <h2
+            id="perf-consent-title"
+            className="text-sm font-semibold text-foreground"
+          >
+            Anonymous performance monitoring
+          </h2>
+          <p
+            id="perf-consent-desc"
+            className="mt-1 text-xs leading-relaxed text-foreground-muted"
+          >
+            Help us improve StellarSwipe by sharing anonymous metrics: page load
+            times, API latency, crash reports, and device performance. No
+            personal data or wallet info is collected.
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setConsent("granted")}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-sky-600 px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
+            >
+              <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+              Allow monitoring
+            </button>
+            <button
+              type="button"
+              onClick={() => setConsent("denied")}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-surface px-3 py-1.5 text-xs font-semibold text-foreground-muted transition-colors hover:bg-surface-high focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+              Decline
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/performance/PerformanceMonitoringProvider.tsx
+++ b/components/performance/PerformanceMonitoringProvider.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  initPerformanceMonitoring,
+  onConsentChanged,
+  teardownPerformanceMonitoring,
+} from "@/services/performanceMonitoring";
+import { usePerformanceMonitoringStore } from "@/store/usePerformanceMonitoringStore";
+import { useRouteLoadTracking } from "@/hooks/useRouteLoadTracking";
+import { PerformanceMonitoringConsent } from "./PerformanceMonitoringConsent";
+
+export function PerformanceMonitoringProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const consent = usePerformanceMonitoringStore((s) => s.consent);
+
+  useRouteLoadTracking();
+
+  useEffect(() => {
+    if (consent === "granted") {
+      void initPerformanceMonitoring();
+    } else {
+      teardownPerformanceMonitoring();
+    }
+
+    return () => teardownPerformanceMonitoring();
+  }, [consent]);
+
+  useEffect(() => {
+    onConsentChanged(consent === "granted");
+  }, [consent]);
+
+  return (
+    <>
+      {children}
+      <PerformanceMonitoringConsent />
+    </>
+  );
+}

--- a/hooks/usePortfolio.ts
+++ b/hooks/usePortfolio.ts
@@ -3,7 +3,17 @@
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useWallet } from "@/hooks/useWallet";
-import { usePortfolioStore } from "@/store/usePortfolioStore";
+import { usePortfolioStore, type PortfolioAsset } from "@/store/usePortfolioStore";
+
+function withPercentages(
+  assets: Omit<PortfolioAsset, "percentage">[]
+): PortfolioAsset[] {
+  const total = assets.reduce((sum, a) => sum + a.value, 0);
+  return assets.map((a) => ({
+    ...a,
+    percentage: total > 0 ? Math.round((a.value / total) * 1000) / 10 : 0,
+  }));
+}
 
 export function usePortfolio() {
   const { publicKey, connected } = useWallet();
@@ -12,24 +22,24 @@ export function usePortfolio() {
   // Initialize with demo data if store is empty
   useEffect(() => {
     if (store.assets.length === 0 && !connected) {
-      const demoPortfolio = [
+      const demoPortfolio = withPercentages([
         { symbol: "XLM", name: "Stellar", value: 1500, color: "#0d1f2d", realizedPnL: 120, unrealizedPnL: 85 },
         { symbol: "USDC", name: "USD Coin", value: 800, color: "#2775ca", realizedPnL: 45, unrealizedPnL: 12 },
         { symbol: "AQUA", name: "Aqua", value: 350, color: "#00c5ff", realizedPnL: -20, unrealizedPnL: 28 },
         { symbol: "yXLM", name: "Yield XLM", value: 200, color: "#7b61ff", realizedPnL: 60, unrealizedPnL: 35 },
-      ];
+      ]);
       store.setAssets(demoPortfolio);
     }
   }, [store, connected]);
 
   const fetchPortfolio = async () => {
     // In real app, fetch from API based on publicKey
-    const realPortfolio = [
+    const realPortfolio = withPercentages([
       { symbol: "XLM", name: "Stellar", value: 1500, color: "#0d1f2d", realizedPnL: 120, unrealizedPnL: 85 },
       { symbol: "USDC", name: "USD Coin", value: 800, color: "#2775ca", realizedPnL: 45, unrealizedPnL: 12 },
       { symbol: "AQUA", name: "Aqua", value: 350, color: "#00c5ff", realizedPnL: -20, unrealizedPnL: 28 },
       { symbol: "yXLM", name: "Yield XLM", value: 200, color: "#7b61ff", realizedPnL: 60, unrealizedPnL: 35 },
-    ];
+    ]);
     return realPortfolio;
   };
 

--- a/hooks/useRouteLoadTracking.ts
+++ b/hooks/useRouteLoadTracking.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { recordRouteLoad } from "@/services/performanceMonitoring";
+import { isMonitoringEnabled } from "@/store/usePerformanceMonitoringStore";
+
+/**
+ * Tracks per-route load time using navigation timing and pathname changes.
+ */
+export function useRouteLoadTracking(): void {
+  const pathname = usePathname();
+  const navigationStartRef = useRef<number>(0);
+  const prevPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isMonitoringEnabled()) return;
+
+    navigationStartRef.current = performance.now();
+    prevPathRef.current = pathname;
+
+    const reportLoad = () => {
+      const loadTimeMs = Math.round(performance.now() - navigationStartRef.current);
+      recordRouteLoad(pathname, loadTimeMs);
+    };
+
+    // Report after paint
+    const raf = requestAnimationFrame(() => {
+      requestAnimationFrame(reportLoad);
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [pathname]);
+}

--- a/hooks/useScrollAnimation.ts
+++ b/hooks/useScrollAnimation.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useReducedMotion } from "framer-motion";
+import { useReducedMotion, type Variants } from "framer-motion";
 
-export const fadeUpVariants = {
+export const fadeUpVariants: Variants = {
   hidden: { opacity: 0, y: 24 },
   visible: (i = 0) => ({
     opacity: 1,
@@ -11,7 +11,7 @@ export const fadeUpVariants = {
   }),
 };
 
-export const fadeInVariants = {
+export const fadeInVariants: Variants = {
   hidden: { opacity: 0 },
   visible: (i = 0) => ({
     opacity: 1,

--- a/lib/performance/device.ts
+++ b/lib/performance/device.ts
@@ -1,0 +1,130 @@
+import type { DeviceSnapshot, NetworkConnectionType } from "./types";
+
+interface NavigatorConnection {
+  effectiveType?: string;
+  type?: string;
+  downlink?: number;
+}
+
+interface NavigatorWithMemory extends Navigator {
+  deviceMemory?: number;
+  connection?: NavigatorConnection;
+  getBattery?: () => Promise<{
+    level: number;
+    charging: boolean;
+  }>;
+}
+
+function detectOs(userAgent: string, platform: string): string {
+  if (/android/i.test(userAgent)) return "Android";
+  if (/iphone|ipad|ipod/i.test(userAgent)) return "iOS";
+  if (/win/i.test(platform)) return "Windows";
+  if (/mac/i.test(platform)) return "macOS";
+  if (/linux/i.test(platform)) return "Linux";
+  return "Unknown";
+}
+
+function detectDeviceType(
+  userAgent: string,
+  width: number
+): DeviceSnapshot["deviceType"] {
+  if (/ipad|tablet/i.test(userAgent) || (width >= 768 && width < 1024)) {
+    return "tablet";
+  }
+  if (/mobile|iphone|android/i.test(userAgent) || width < 768) {
+    return "mobile";
+  }
+  return "desktop";
+}
+
+export function resolveNetworkType(): NetworkConnectionType {
+  if (typeof navigator === "undefined") return "unknown";
+  if (!navigator.onLine) return "offline";
+
+  const nav = navigator as NavigatorWithMemory;
+  const connection = nav.connection;
+  if (!connection?.type && !connection?.effectiveType) return "unknown";
+
+  const type = (connection.type ?? connection.effectiveType ?? "").toLowerCase();
+  if (type.includes("wifi")) return "wifi";
+  if (type.includes("wimax")) return "wifi";
+  if (
+    type.includes("cellular") ||
+    type.includes("2g") ||
+    type.includes("3g") ||
+    type.includes("4g") ||
+    type.includes("5g")
+  ) {
+    return "cellular";
+  }
+  if (type.includes("ethernet")) return "ethernet";
+  return "unknown";
+}
+
+export async function getDeviceSnapshot(): Promise<DeviceSnapshot> {
+  if (typeof window === "undefined") {
+    return {
+      userAgent: "",
+      platform: "",
+      os: "Unknown",
+      deviceType: "desktop",
+      screenWidth: 0,
+      screenHeight: 0,
+      memoryMb: null,
+      batteryLevel: null,
+      batteryCharging: null,
+      networkType: "unknown",
+    };
+  }
+
+  const nav = navigator as NavigatorWithMemory;
+  const userAgent = nav.userAgent;
+  const platform = nav.platform ?? "";
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+
+  let batteryLevel: number | null = null;
+  let batteryCharging: boolean | null = null;
+
+  if (nav.getBattery) {
+    try {
+      const battery = await nav.getBattery();
+      batteryLevel = Math.round(battery.level * 100);
+      batteryCharging = battery.charging;
+    } catch {
+      // Battery API unavailable
+    }
+  }
+
+  const memoryGb = nav.deviceMemory;
+  const memoryMb = typeof memoryGb === "number" ? memoryGb * 1024 : null;
+
+  return {
+    userAgent,
+    platform,
+    os: detectOs(userAgent, platform),
+    deviceType: detectDeviceType(userAgent, width),
+    screenWidth: width,
+    screenHeight: height,
+    memoryMb,
+    batteryLevel,
+    batteryCharging,
+    networkType: resolveNetworkType(),
+  };
+}
+
+export function getMemoryUsageMb(): { usedMb: number | null; totalMb: number | null } {
+  if (typeof performance === "undefined") {
+    return { usedMb: null, totalMb: null };
+  }
+
+  const memory = (performance as Performance & { memory?: { usedJSHeapSize: number; totalJSHeapSize: number } }).memory;
+  if (!memory) {
+    return { usedMb: null, totalMb: null };
+  }
+
+  return {
+    usedMb: Math.round(memory.usedJSHeapSize / (1024 * 1024)),
+    totalMb: Math.round(memory.totalJSHeapSize / (1024 * 1024)),
+  };
+}

--- a/lib/performance/types.ts
+++ b/lib/performance/types.ts
@@ -1,0 +1,99 @@
+export type NetworkConnectionType =
+  | "wifi"
+  | "cellular"
+  | "ethernet"
+  | "unknown"
+  | "offline";
+
+export type ConsentStatus = "pending" | "granted" | "denied";
+
+export interface RouteLoadMetric {
+  route: string;
+  loadTimeMs: number;
+  timestamp: string;
+}
+
+export interface ApiResponseMetric {
+  url: string;
+  method: string;
+  durationMs: number;
+  status: number | null;
+  networkType: NetworkConnectionType;
+  timestamp: string;
+}
+
+export interface CrashReport {
+  id: string;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  route: string;
+  timestamp: string;
+  sessionSnapshot: SessionEvent[];
+  device: DeviceSnapshot;
+}
+
+export interface SessionEvent {
+  type: "navigation" | "click" | "api" | "error" | "custom";
+  label: string;
+  timestamp: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface HeatmapPoint {
+  x: number;
+  y: number;
+  route: string;
+  timestamp: string;
+}
+
+export interface DeviceSnapshot {
+  userAgent: string;
+  platform: string;
+  os: string;
+  deviceType: "mobile" | "tablet" | "desktop";
+  screenWidth: number;
+  screenHeight: number;
+  memoryMb: number | null;
+  batteryLevel: number | null;
+  batteryCharging: boolean | null;
+  networkType: NetworkConnectionType;
+}
+
+export interface MemorySample {
+  usedMb: number | null;
+  totalMb: number | null;
+  timestamp: string;
+}
+
+export interface BatterySample {
+  level: number | null;
+  charging: boolean | null;
+  timestamp: string;
+}
+
+export interface PerformanceMetricsSummary {
+  routeLoads: RouteLoadMetric[];
+  apiResponses: ApiResponseMetric[];
+  crashes: CrashReport[];
+  heatmap: HeatmapPoint[];
+  memorySamples: MemorySample[];
+  batterySamples: BatterySample[];
+  device: DeviceSnapshot | null;
+  networkBreakdown: Record<NetworkConnectionType, { count: number; avgApiMs: number }>;
+}
+
+export type PerformanceEventType =
+  | "route_load"
+  | "api_response"
+  | "crash"
+  | "heatmap"
+  | "memory"
+  | "battery"
+  | "session";
+
+export interface PerformanceEvent {
+  type: PerformanceEventType;
+  payload: unknown;
+  timestamp: string;
+}

--- a/services/performanceMonitoring/__tests__/performanceMonitoring.test.ts
+++ b/services/performanceMonitoring/__tests__/performanceMonitoring.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for performance monitoring store and service
+ */
+
+import {
+  isMonitoringEnabled,
+  usePerformanceMonitoringStore,
+} from "@/store/usePerformanceMonitoringStore";
+import {
+  recordApiResponse,
+  recordCrash,
+  recordRouteLoad,
+  teardownPerformanceMonitoring,
+} from "@/services/performanceMonitoring";
+
+beforeEach(() => {
+  usePerformanceMonitoringStore.setState({
+    consent: "granted",
+    routeLoads: [],
+    apiResponses: [],
+    crashes: [],
+    heatmap: [],
+    memorySamples: [],
+    batterySamples: [],
+    sessionEvents: [],
+  });
+  teardownPerformanceMonitoring();
+});
+
+describe("performance monitoring store", () => {
+  it("requires consent before enabling monitoring", () => {
+    usePerformanceMonitoringStore.getState().setConsent("denied");
+    expect(isMonitoringEnabled()).toBe(false);
+
+    usePerformanceMonitoringStore.getState().setConsent("granted");
+    expect(isMonitoringEnabled()).toBe(true);
+  });
+
+  it("records route load metrics", () => {
+    recordRouteLoad("/app", 120);
+    const summary = usePerformanceMonitoringStore.getState().getSummary();
+    expect(summary.routeLoads).toHaveLength(1);
+    expect(summary.routeLoads[0]).toMatchObject({
+      route: "/app",
+      loadTimeMs: 120,
+    });
+  });
+
+  it("records API response metrics with network type", () => {
+    recordApiResponse("/api/signals", "GET", 85, 200);
+    const summary = usePerformanceMonitoringStore.getState().getSummary();
+    expect(summary.apiResponses).toHaveLength(1);
+    expect(summary.apiResponses[0].durationMs).toBe(85);
+    expect(summary.networkBreakdown).toBeDefined();
+  });
+
+  it("records crash reports with session snapshot", () => {
+    recordRouteLoad("/app", 50);
+    recordCrash("Test error", "Error: Test error\n  at foo");
+    const summary = usePerformanceMonitoringStore.getState().getSummary();
+    expect(summary.crashes).toHaveLength(1);
+    expect(summary.crashes[0].message).toBe("Test error");
+    expect(summary.crashes[0].stack).toContain("Test error");
+    expect(summary.crashes[0].sessionSnapshot.length).toBeGreaterThan(0);
+  });
+
+  it("does not record metrics when consent is denied", () => {
+    usePerformanceMonitoringStore.getState().setConsent("denied");
+    recordRouteLoad("/app", 100);
+    recordApiResponse("/api/test", "GET", 50, 200);
+    const summary = usePerformanceMonitoringStore.getState().getSummary();
+    expect(summary.routeLoads).toHaveLength(0);
+    expect(summary.apiResponses).toHaveLength(0);
+  });
+});

--- a/services/performanceMonitoring/index.ts
+++ b/services/performanceMonitoring/index.ts
@@ -1,0 +1,326 @@
+import type { Span } from "@/src/tracing/worker-tracing.service";
+import {
+  getDeviceSnapshot,
+  getMemoryUsageMb,
+  resolveNetworkType,
+} from "@/lib/performance/device";
+import type {
+  ApiResponseMetric,
+  CrashReport,
+  HeatmapPoint,
+  RouteLoadMetric,
+  SessionEvent,
+} from "@/lib/performance/types";
+import {
+  getSessionSnapshot,
+  isMonitoringEnabled,
+  usePerformanceMonitoringStore,
+} from "@/store/usePerformanceMonitoringStore";
+
+let fetchPatched = false;
+let initialized = false;
+let memoryInterval: ReturnType<typeof setInterval> | null = null;
+let batteryInterval: ReturnType<typeof setInterval> | null = null;
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function getCurrentRoute(): string {
+  if (typeof window === "undefined") return "/";
+  return window.location.pathname;
+}
+
+function recordSession(
+  type: SessionEvent["type"],
+  label: string,
+  metadata?: SessionEvent["metadata"]
+): void {
+  if (!isMonitoringEnabled()) return;
+  usePerformanceMonitoringStore.getState().recordSessionEvent({
+    type,
+    label,
+    timestamp: now(),
+    metadata,
+  });
+}
+
+export function recordRouteLoad(route: string, loadTimeMs: number): void {
+  if (!isMonitoringEnabled()) return;
+
+  const metric: RouteLoadMetric = {
+    route,
+    loadTimeMs,
+    timestamp: now(),
+  };
+
+  usePerformanceMonitoringStore.getState().recordRouteLoad(metric);
+  recordSession("navigation", route, { loadTimeMs });
+}
+
+export function recordApiResponse(
+  url: string,
+  method: string,
+  durationMs: number,
+  status: number | null
+): void {
+  if (!isMonitoringEnabled()) return;
+
+  const metric: ApiResponseMetric = {
+    url,
+    method,
+    durationMs,
+    status,
+    networkType: resolveNetworkType(),
+    timestamp: now(),
+  };
+
+  usePerformanceMonitoringStore.getState().recordApiResponse(metric);
+  recordSession("api", `${method} ${url}`, { durationMs, status: status ?? -1 });
+}
+
+export function recordCrash(
+  message: string,
+  stack?: string,
+  componentStack?: string
+): void {
+  if (!isMonitoringEnabled()) return;
+
+  const store = usePerformanceMonitoringStore.getState();
+  const device = store.device;
+
+  const report: CrashReport = {
+    id: `crash_${Date.now().toString(36)}`,
+    message,
+    stack,
+    componentStack,
+    route: getCurrentRoute(),
+    timestamp: now(),
+    sessionSnapshot: getSessionSnapshot(),
+    device: device ?? {
+      userAgent: "",
+      platform: "",
+      os: "Unknown",
+      deviceType: "desktop",
+      screenWidth: 0,
+      screenHeight: 0,
+      memoryMb: null,
+      batteryLevel: null,
+      batteryCharging: null,
+      networkType: resolveNetworkType(),
+    },
+  };
+
+  store.recordCrash(report);
+  recordSession("error", message);
+}
+
+export function recordHeatmapPoint(x: number, y: number, route: string): void {
+  if (!isMonitoringEnabled()) return;
+
+  const point: HeatmapPoint = {
+    x: Math.round(x),
+    y: Math.round(y),
+    route,
+    timestamp: now(),
+  };
+
+  usePerformanceMonitoringStore.getState().recordHeatmapPoint(point);
+  recordSession("click", route, { x: point.x, y: point.y });
+}
+
+export function recordTracingSpan(span: Span): void {
+  if (!isMonitoringEnabled()) return;
+
+  recordApiResponse(
+    span.name,
+    "TRACE",
+    span.durationMs ?? 0,
+    span.status === "error" ? 500 : 200
+  );
+}
+
+function patchFetch(): void {
+  if (fetchPatched || typeof window === "undefined") return;
+  fetchPatched = true;
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const start = performance.now();
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+    const method = init?.method ?? "GET";
+
+    try {
+      const response = await originalFetch(input, init);
+      recordApiResponse(url, method, Math.round(performance.now() - start), response.status);
+      return response;
+    } catch (err) {
+      recordApiResponse(url, method, Math.round(performance.now() - start), null);
+      throw err;
+    }
+  };
+}
+
+function startResourceObserver(): void {
+  if (typeof PerformanceObserver === "undefined") return;
+
+  try {
+    const observer = new PerformanceObserver((list) => {
+      const entries = list.getEntriesByType(
+        "navigation"
+      ) as PerformanceNavigationTiming[];
+      for (const entry of entries) {
+        if (entry.entryType === "navigation") {
+          recordRouteLoad(
+            getCurrentRoute(),
+            Math.round(entry.loadEventEnd - entry.startTime)
+          );
+        }
+      }
+    });
+    observer.observe({ type: "navigation", buffered: true });
+  } catch {
+    // PerformanceObserver not supported
+  }
+}
+
+function startMemorySampling(): void {
+  if (memoryInterval) return;
+
+  memoryInterval = setInterval(() => {
+    if (!isMonitoringEnabled()) return;
+    const { usedMb, totalMb } = getMemoryUsageMb();
+    usePerformanceMonitoringStore.getState().recordMemorySample({
+      usedMb,
+      totalMb,
+      timestamp: now(),
+    });
+  }, 30_000);
+}
+
+async function sampleBattery(): Promise<void> {
+  if (!isMonitoringEnabled()) return;
+
+  const nav = navigator as Navigator & {
+    getBattery?: () => Promise<{ level: number; charging: boolean }>;
+  };
+
+  if (!nav.getBattery) return;
+
+  try {
+    const battery = await nav.getBattery();
+    usePerformanceMonitoringStore.getState().recordBatterySample({
+      level: Math.round(battery.level * 100),
+      charging: battery.charging,
+      timestamp: now(),
+    });
+  } catch {
+    // Battery API unavailable
+  }
+}
+
+function startBatterySampling(): void {
+  if (batteryInterval) return;
+  void sampleBattery();
+  batteryInterval = setInterval(() => {
+    void sampleBattery();
+  }, 60_000);
+}
+
+function attachGlobalErrorHandlers(): void {
+  if (typeof window === "undefined") return;
+
+  window.addEventListener("error", (event) => {
+    recordCrash(event.message, event.error?.stack);
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    const message =
+      reason instanceof Error ? reason.message : String(reason ?? "Unhandled rejection");
+    const stack = reason instanceof Error ? reason.stack : undefined;
+    recordCrash(message, stack);
+  });
+
+  window.addEventListener("app-error", ((event: CustomEvent) => {
+    const detail = event.detail as {
+      message?: string;
+      stack?: string;
+      componentStack?: string;
+    };
+    recordCrash(
+      detail.message ?? "React error",
+      detail.stack,
+      detail.componentStack
+    );
+  }) as EventListener);
+}
+
+function attachHeatmapListeners(): void {
+  if (typeof window === "undefined") return;
+
+  const handler = (event: MouseEvent | TouchEvent) => {
+    if (!isMonitoringEnabled()) return;
+
+    let clientX = 0;
+    let clientY = 0;
+
+    if ("touches" in event && event.touches.length > 0) {
+      clientX = event.touches[0].clientX;
+      clientY = event.touches[0].clientY;
+    } else if ("clientX" in event) {
+      clientX = event.clientX;
+      clientY = event.clientY;
+    }
+
+    const x = (clientX / window.innerWidth) * 100;
+    const y = (clientY / window.innerHeight) * 100;
+    recordHeatmapPoint(x, y, getCurrentRoute());
+  };
+
+  window.addEventListener("click", handler, { passive: true });
+  window.addEventListener("touchstart", handler, { passive: true });
+}
+
+export async function initPerformanceMonitoring(): Promise<void> {
+  if (initialized || typeof window === "undefined") return;
+  if (!isMonitoringEnabled()) return;
+
+  initialized = true;
+
+  const device = await getDeviceSnapshot();
+  usePerformanceMonitoringStore.getState().setDevice(device);
+
+  patchFetch();
+  startResourceObserver();
+  startMemorySampling();
+  startBatterySampling();
+  attachGlobalErrorHandlers();
+  attachHeatmapListeners();
+}
+
+export function teardownPerformanceMonitoring(): void {
+  if (memoryInterval) {
+    clearInterval(memoryInterval);
+    memoryInterval = null;
+  }
+  if (batteryInterval) {
+    clearInterval(batteryInterval);
+    batteryInterval = null;
+  }
+  initialized = false;
+}
+
+export function onConsentChanged(granted: boolean): void {
+  if (granted) {
+    void initPerformanceMonitoring();
+  } else {
+    teardownPerformanceMonitoring();
+  }
+}

--- a/src/tracing/worker-tracing.service.ts
+++ b/src/tracing/worker-tracing.service.ts
@@ -42,8 +42,14 @@ function emit(span: Span): void {
       span
     );
   }
-  // Production hook: forward to your observability backend here.
-  // e.g. sendToDatadog(span) / sendToOpenTelemetry(span)
+
+  if (typeof window !== "undefined") {
+    import("@/services/performanceMonitoring")
+      .then(({ recordTracingSpan }) => recordTracingSpan(span))
+      .catch(() => {
+        // Performance monitoring not available
+      });
+  }
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────

--- a/store/leaderboardStore.ts
+++ b/store/leaderboardStore.ts
@@ -1,5 +1,5 @@
 // store/leaderboardStore.ts
-import create from "zustand";
+import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
 export type LeaderboardEntry = {

--- a/store/usePerformanceMonitoringStore.ts
+++ b/store/usePerformanceMonitoringStore.ts
@@ -1,0 +1,196 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type {
+  ApiResponseMetric,
+  BatterySample,
+  ConsentStatus,
+  CrashReport,
+  DeviceSnapshot,
+  HeatmapPoint,
+  MemorySample,
+  NetworkConnectionType,
+  PerformanceMetricsSummary,
+  RouteLoadMetric,
+  SessionEvent,
+} from "@/lib/performance/types";
+
+const MAX_ROUTE_LOADS = 100;
+const MAX_API_RESPONSES = 200;
+const MAX_CRASHES = 50;
+const MAX_HEATMAP = 500;
+const MAX_MEMORY_SAMPLES = 60;
+const MAX_BATTERY_SAMPLES = 60;
+const MAX_SESSION_EVENTS = 100;
+
+interface PerformanceMonitoringState {
+  consent: ConsentStatus;
+  anonymousSessionId: string;
+  device: DeviceSnapshot | null;
+  routeLoads: RouteLoadMetric[];
+  apiResponses: ApiResponseMetric[];
+  crashes: CrashReport[];
+  heatmap: HeatmapPoint[];
+  memorySamples: MemorySample[];
+  batterySamples: BatterySample[];
+  sessionEvents: SessionEvent[];
+
+  setConsent: (status: ConsentStatus) => void;
+  setDevice: (device: DeviceSnapshot) => void;
+  recordRouteLoad: (metric: RouteLoadMetric) => void;
+  recordApiResponse: (metric: ApiResponseMetric) => void;
+  recordCrash: (report: CrashReport) => void;
+  recordHeatmapPoint: (point: HeatmapPoint) => void;
+  recordMemorySample: (sample: MemorySample) => void;
+  recordBatterySample: (sample: BatterySample) => void;
+  recordSessionEvent: (event: SessionEvent) => void;
+  getSummary: () => PerformanceMetricsSummary;
+  clearMetrics: () => void;
+}
+
+function createAnonymousId(): string {
+  return `anon_${Math.random().toString(36).slice(2, 10)}_${Date.now().toString(36)}`;
+}
+
+function trimArray<T>(arr: T[], max: number): T[] {
+  return arr.length > max ? arr.slice(arr.length - max) : arr;
+}
+
+function buildNetworkBreakdown(
+  apiResponses: ApiResponseMetric[]
+): PerformanceMetricsSummary["networkBreakdown"] {
+  const types: NetworkConnectionType[] = [
+    "wifi",
+    "cellular",
+    "ethernet",
+    "unknown",
+    "offline",
+  ];
+
+  const breakdown = {} as PerformanceMetricsSummary["networkBreakdown"];
+  for (const type of types) {
+    const entries = apiResponses.filter((e) => e.networkType === type);
+    const count = entries.length;
+    const avgApiMs =
+      count > 0
+        ? Math.round(entries.reduce((sum, e) => sum + e.durationMs, 0) / count)
+        : 0;
+    breakdown[type] = { count, avgApiMs };
+  }
+  return breakdown;
+}
+
+export const usePerformanceMonitoringStore = create<PerformanceMonitoringState>()(
+  persist(
+    (set, get) => ({
+      consent: "pending",
+      anonymousSessionId: createAnonymousId(),
+      device: null,
+      routeLoads: [],
+      apiResponses: [],
+      crashes: [],
+      heatmap: [],
+      memorySamples: [],
+      batterySamples: [],
+      sessionEvents: [],
+
+      setConsent: (status) => set({ consent: status }),
+
+      setDevice: (device) => set({ device }),
+
+      recordRouteLoad: (metric) =>
+        set((state) => ({
+          routeLoads: trimArray([...state.routeLoads, metric], MAX_ROUTE_LOADS),
+        })),
+
+      recordApiResponse: (metric) =>
+        set((state) => ({
+          apiResponses: trimArray(
+            [...state.apiResponses, metric],
+            MAX_API_RESPONSES
+          ),
+        })),
+
+      recordCrash: (report) =>
+        set((state) => ({
+          crashes: trimArray([...state.crashes, report], MAX_CRASHES),
+        })),
+
+      recordHeatmapPoint: (point) =>
+        set((state) => ({
+          heatmap: trimArray([...state.heatmap, point], MAX_HEATMAP),
+        })),
+
+      recordMemorySample: (sample) =>
+        set((state) => ({
+          memorySamples: trimArray(
+            [...state.memorySamples, sample],
+            MAX_MEMORY_SAMPLES
+          ),
+        })),
+
+      recordBatterySample: (sample) =>
+        set((state) => ({
+          batterySamples: trimArray(
+            [...state.batterySamples, sample],
+            MAX_BATTERY_SAMPLES
+          ),
+        })),
+
+      recordSessionEvent: (event) =>
+        set((state) => ({
+          sessionEvents: trimArray(
+            [...state.sessionEvents, event],
+            MAX_SESSION_EVENTS
+          ),
+        })),
+
+      getSummary: () => {
+        const state = get();
+        return {
+          routeLoads: state.routeLoads,
+          apiResponses: state.apiResponses,
+          crashes: state.crashes,
+          heatmap: state.heatmap,
+          memorySamples: state.memorySamples,
+          batterySamples: state.batterySamples,
+          device: state.device,
+          networkBreakdown: buildNetworkBreakdown(state.apiResponses),
+        };
+      },
+
+      clearMetrics: () =>
+        set({
+          routeLoads: [],
+          apiResponses: [],
+          crashes: [],
+          heatmap: [],
+          memorySamples: [],
+          batterySamples: [],
+          sessionEvents: [],
+        }),
+    }),
+    {
+      name: "stellar-performance-monitoring",
+      partialize: (state) => ({
+        consent: state.consent,
+        anonymousSessionId: state.anonymousSessionId,
+        routeLoads: state.routeLoads,
+        apiResponses: state.apiResponses,
+        crashes: state.crashes,
+        heatmap: state.heatmap,
+        memorySamples: state.memorySamples,
+        batterySamples: state.batterySamples,
+      }),
+    }
+  )
+);
+
+export function isMonitoringEnabled(): boolean {
+  return usePerformanceMonitoringStore.getState().consent === "granted";
+}
+
+export function getSessionSnapshot(): SessionEvent[] {
+  return [...usePerformanceMonitoringStore.getState().sessionEvents];
+}

--- a/store/useThemeStore.ts
+++ b/store/useThemeStore.ts
@@ -20,7 +20,6 @@ export const useThemeStore = create<ThemeState>()(
     }),
     {
       name: "stellar-theme",
-      getStorage: () => (typeof window !== "undefined" ? localStorage : undefined),
     }
   )
 );


### PR DESCRIPTION
## Summary

closes #169

- Implements anonymous, consent-gated performance monitoring for the mobile web app
- Tracks page load times per route, API latency, crashes (with stack traces), session event buffers, interaction heatmaps, device/OS info, network-type impact, memory, and battery usage
- Adds a `/performance` dashboard to visualize collected metrics
- Wires monitoring into the app shell via `PerformanceMonitoringProvider` and forwards worker tracing spans to the monitoring service

## Acceptance criteria

- [x] Page load time tracking per route
- [x] API response time monitoring
- [x] Crash reporting with stack traces
- [x] Session recording for error debugging
- [x] User interaction heatmaps
- [x] Device and OS performance breakdown
- [x] Network type impact analysis (WiFi vs mobile)
- [x] Memory usage monitoring
- [x] Battery consumption tracking
- [x] Anonymous user consent required

## Test plan

- [ ] Load the app — consent banner appears; no metrics collected until accepted
- [ ] Accept consent — navigate between routes and confirm load times appear on `/performance`
- [ ] Trigger API calls (e.g. signals feed) — verify API latency and network breakdown update
- [ ] Click/tap around the UI — verify heatmap points appear on `/performance`
- [ ] Decline consent — confirm collection stops and dashboard shows re-enable option
- [ ] Run `npm run build` — passes
- [ ] Run performance monitoring unit tests — passes