### PR TITLE
feat: cross-tab sync, compare deep link, backtest export, dynamic imports

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,16 +1,41 @@
 "use client"
 
-import React from 'react'
+import dynamic from "next/dynamic"
 
-export default function AnalyticsPage(){
+const PortfolioAllocationChart = dynamic(
+  () => import("@/components/chart/PortfolioAllocationChart"),
+  {
+    loading: () => <div className="animate-pulse h-48 bg-white/10 rounded" />,
+    ssr: false,
+  }
+)
+
+const PnLWidget = dynamic(
+  () => import("@/components/chart/PnLWidget"),
+  {
+    loading: () => <div className="animate-pulse h-48 bg-white/10 rounded" />,
+    ssr: false,
+  }
+)
+
+const PerformanceDashboard = dynamic(
+  () => import("@/components/performance/PerformanceDashboard").then((m) => m.PerformanceDashboard),
+  {
+    loading: () => <div className="animate-pulse h-64 bg-white/10 rounded" />,
+    ssr: false,
+  }
+)
+
+export default function AnalyticsPage() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Portfolio Analytics</h1>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="bg-white/5 p-4 rounded">Portfolio value chart placeholder</div>
-        <div className="bg-white/5 p-4 rounded">Returns & risk metrics placeholder</div>
-        <div className="bg-white/5 p-4 rounded">Performance attribution placeholder</div>
-        <div className="bg-white/5 p-4 rounded">Correlation & heatmap placeholder</div>
+        <PortfolioAllocationChart />
+        <PnLWidget />
+        <div className="md:col-span-2">
+          <PerformanceDashboard />
+        </div>
       </div>
     </div>
   )

--- a/app/backtest-sim/page.tsx
+++ b/app/backtest-sim/page.tsx
@@ -1,7 +1,16 @@
 "use client"
 
-import React from "react";
-import BacktestTool from "../../components/BacktestTool";
+import dynamic from "next/dynamic"
+
+const BacktestTool = dynamic(() => import("../../components/BacktestTool"), {
+  loading: () => (
+    <div className="animate-pulse space-y-3 p-4">
+      <div className="h-8 bg-white/10 rounded w-48" />
+      <div className="h-32 bg-white/10 rounded" />
+    </div>
+  ),
+  ssr: false,
+})
 
 export default function BacktestPage() {
   return (
@@ -9,5 +18,5 @@ export default function BacktestPage() {
       <h1 className="text-2xl font-bold mb-4">Signal Backtesting Simulation</h1>
       <BacktestTool />
     </div>
-  );
+  )
 }

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,15 +1,28 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import { motion, AnimatePresence } from "framer-motion";
-import { Plus, Trash2, Printer, GitCompare } from "lucide-react";
+import { Plus, Trash2, Printer, GitCompare, Link as LinkIcon, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageTransition } from "@/components/PageTransition";
 import { useComparisonStore } from "@/store/useComparisonStore";
-import { ComparisonCard } from "@/components/comparison/ComparisonCard";
 import { MetricToggleBar } from "@/components/comparison/MetricToggleBar";
-import { ComparisonChart } from "@/components/comparison/ComparisonChart";
-import { AddSignalPanel } from "@/components/comparison/AddSignalPanel";
+import { fetchSignals } from "@/lib/api";
+
+const ComparisonCard = dynamic(
+  () => import("@/components/comparison/ComparisonCard").then((m) => m.ComparisonCard),
+  { loading: () => <div className="animate-pulse h-48 bg-white/5 rounded-xl" />, ssr: false }
+);
+const ComparisonChart = dynamic(
+  () => import("@/components/comparison/ComparisonChart").then((m) => m.ComparisonChart),
+  { loading: () => <div className="animate-pulse h-32 bg-white/5 rounded-xl" />, ssr: false }
+);
+const AddSignalPanel = dynamic(
+  () => import("@/components/comparison/AddSignalPanel").then((m) => m.AddSignalPanel),
+  { loading: () => <div className="animate-pulse h-20 bg-white/5 rounded" />, ssr: false }
+);
 
 function computeBestValues(signals: ReturnType<typeof useComparisonStore.getState>["signals"]): Record<string, number> {
   const best: Record<string, number> = {};
@@ -33,8 +46,43 @@ function computeBestValues(signals: ReturnType<typeof useComparisonStore.getStat
 }
 
 export default function ComparePage() {
-  const { signals, removeSignal, clearSignals, hiddenMetrics, toggleMetric, canAdd } = useComparisonStore();
+  const { signals, removeSignal, clearSignals, hiddenMetrics, toggleMetric, canAdd, addSignal } = useComparisonStore();
   const [addPanelOpen, setAddPanelOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // On mount: restore comparison from URL ?ids=a,b,c
+  useEffect(() => {
+    const ids = searchParams.get("ids");
+    if (!ids || signals.length > 0) return;
+    const idList = ids.split(",").filter(Boolean).slice(0, 3);
+    fetchSignals()
+      .then((all) => {
+        for (const id of idList) {
+          const found = all.find((s) => s.id === id);
+          if (found) addSignal(found);
+        }
+      })
+      .catch(() => {
+        // gracefully ignore — signal may no longer exist
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep URL in sync with current selection
+  useEffect(() => {
+    const ids = signals.map((s) => s.id).join(",");
+    const params = ids ? `?ids=${ids}` : "";
+    router.replace(`/compare${params}`, { scroll: false });
+  }, [signals, router]);
+
+  const handleCopyShareLink = async () => {
+    const url = window.location.href;
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   const bestValues = computeBestValues(signals);
 
@@ -58,6 +106,10 @@ export default function ComparePage() {
             <div className="flex items-center gap-2 print:hidden">
               {signals.length > 0 && (
                 <>
+                  <Button variant="outline" size="sm" onClick={handleCopyShareLink} className="gap-2">
+                    {copied ? <Check className="h-4 w-4 text-green-400" /> : <LinkIcon className="h-4 w-4" />}
+                    {copied ? "Copied!" : "Share Link"}
+                  </Button>
                   <Button variant="outline" size="sm" onClick={handleExportPDF} className="gap-2">
                     <Printer className="h-4 w-4" />
                     Export PDF

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -7,8 +7,11 @@ import { queryClient } from "@/lib/queryClient";
 import { ToastProvider } from "@/components/ui/toast";
 import { initI18n } from "@/lib/i18n";
 import { PerformanceMonitoringProvider } from "@/components/performance/PerformanceMonitoringProvider";
+import { useCrossTabSync } from "@/hooks/useCrossTabSync";
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  useCrossTabSync();
+
   useEffect(() => {
     initI18n();
   }, []);

--- a/app/tax-report/page.tsx
+++ b/app/tax-report/page.tsx
@@ -1,10 +1,23 @@
 import type { Metadata } from "next";
-import { TaxReportingTool } from "@/components/TaxReportingTool";
+import dynamic from "next/dynamic";
 
 export const metadata: Metadata = {
   title: "Tax Report | StellarSwipe",
   description: "Generate tax documents from your StellarSwipe trading activity.",
 };
+
+const TaxReportingTool = dynamic(
+  () => import("@/components/TaxReportingTool").then((m) => m.TaxReportingTool),
+  {
+    loading: () => (
+      <div className="animate-pulse space-y-4">
+        <div className="h-8 bg-white/10 rounded w-48" />
+        <div className="h-64 bg-white/10 rounded" />
+      </div>
+    ),
+    ssr: false,
+  }
+);
 
 export default function TaxReportPage() {
   return (

--- a/components/BacktestTool.tsx
+++ b/components/BacktestTool.tsx
@@ -1,42 +1,190 @@
 "use client"
 
 import React, { useState } from 'react'
+import { runBacktest, type BacktestParams, type BacktestResult } from '@/lib/backtest'
+import { Download } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+function downloadFile(content: string, filename: string, mime: string) {
+  const blob = new Blob([content], { type: mime })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function exportCSV(params: BacktestParams, result: BacktestResult) {
+  const header = 'time,pnl\n'
+  const rows = result.trades.map((t) => `${t.time},${t.pnl}`).join('\n')
+  const meta = [
+    `# from,${params.from}`,
+    `# to,${params.to}`,
+    `# signals,${params.signals.join('|')}`,
+    `# slippageBps,${params.slippageBps ?? 0}`,
+    `# feeBps,${params.feeBps ?? 0}`,
+    `# totalReturn,${result.totalReturn}`,
+    `# winRate,${result.winRate}`,
+    `# maxDrawdown,${result.maxDrawdown}`,
+  ].join('\n')
+  downloadFile(`${meta}\n${header}${rows}`, 'backtest-result.csv', 'text/csv')
+}
+
+function exportJSON(params: BacktestParams, result: BacktestResult) {
+  const payload = { inputs: params, results: result }
+  downloadFile(JSON.stringify(payload, null, 2), 'backtest-result.json', 'application/json')
+}
 
 export default function BacktestTool() {
   const [from, setFrom] = useState('2023-01-01')
   const [to, setTo] = useState('2023-12-31')
   const [selected, setSelected] = useState<string[]>([])
+  const [slippageBps, setSlippageBps] = useState(10)
+  const [feeBps, setFeeBps] = useState(10)
+  const [result, setResult] = useState<BacktestResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const params: BacktestParams = { from, to, signals: selected, slippageBps, feeBps }
+
+  async function handleRun() {
+    setLoading(true)
+    setError(null)
+    try {
+      const r = await runBacktest(params)
+      setResult(r)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Simulation failed')
+    } finally {
+      setLoading(false)
+    }
+  }
 
   return (
     <div className="bg-surface border border-border rounded-lg p-4">
-      <div className="flex gap-3 mb-4">
+      {/* Inputs */}
+      <div className="flex flex-wrap gap-4 mb-4">
         <div>
-          <label className="text-xs text-foreground-muted">From</label>
-          <input type="date" value={from} onChange={(e)=>setFrom(e.target.value)} className="block mt-1" />
+          <label className="text-xs text-foreground-muted block mb-1">From</label>
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="block" />
         </div>
         <div>
-          <label className="text-xs text-foreground-muted">To</label>
-          <input type="date" value={to} onChange={(e)=>setTo(e.target.value)} className="block mt-1" />
+          <label className="text-xs text-foreground-muted block mb-1">To</label>
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="block" />
         </div>
         <div>
-          <label className="text-xs text-foreground-muted">Providers / Signals</label>
-          <select multiple value={selected} onChange={(e)=> setSelected(Array.from(e.target.selectedOptions).map(o=>o.value))} className="block mt-1">
+          <label className="text-xs text-foreground-muted block mb-1">Providers / Signals</label>
+          <select
+            multiple
+            value={selected}
+            onChange={(e) => setSelected(Array.from(e.target.selectedOptions).map((o) => o.value))}
+            className="block"
+          >
             <option value="providerA">Provider A</option>
             <option value="providerB">Provider B</option>
             <option value="signalX">Signal X</option>
             <option value="signalY">Signal Y</option>
           </select>
         </div>
+        <div>
+          <label className="text-xs text-foreground-muted block mb-1">Slippage (bps)</label>
+          <input
+            type="number"
+            min={0}
+            value={slippageBps}
+            onChange={(e) => setSlippageBps(Number(e.target.value))}
+            className="block w-20"
+          />
+        </div>
+        <div>
+          <label className="text-xs text-foreground-muted block mb-1">Fee (bps)</label>
+          <input
+            type="number"
+            min={0}
+            value={feeBps}
+            onChange={(e) => setFeeBps(Number(e.target.value))}
+            className="block w-20"
+          />
+        </div>
       </div>
 
-      <div className="flex gap-3">
-        <button className="px-4 py-2 bg-purple-500 rounded text-white">Run Simulation</button>
-        <button className="px-3 py-2 bg-surface-high text-foreground rounded">Export CSV</button>
+      {/* Actions */}
+      <div className="flex gap-3 mb-6">
+        <Button onClick={handleRun} disabled={loading} className="bg-purple-500 text-white">
+          {loading ? 'Running…' : 'Run Simulation'}
+        </Button>
+        <Button
+          variant="outline"
+          disabled={!result}
+          onClick={() => result && exportCSV(params, result)}
+          className="gap-2"
+        >
+          <Download className="h-4 w-4" />
+          Export CSV
+        </Button>
+        <Button
+          variant="outline"
+          disabled={!result}
+          onClick={() => result && exportJSON(params, result)}
+          className="gap-2"
+        >
+          <Download className="h-4 w-4" />
+          Export JSON
+        </Button>
       </div>
 
-      <div className="mt-6 text-gray-400">
-        <p>Simulated results, win rate, drawdown and charts will appear here after running the simulation.</p>
-      </div>
+      {/* Error */}
+      {error && <p className="text-red-400 mb-4">{error}</p>}
+
+      {/* Results */}
+      {result ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-4">
+            <div className="bg-white/5 rounded p-3 text-center">
+              <p className="text-xs text-gray-400 mb-1">Total Return</p>
+              <p className="text-lg font-semibold">{(result.totalReturn * 100).toFixed(2)}%</p>
+            </div>
+            <div className="bg-white/5 rounded p-3 text-center">
+              <p className="text-xs text-gray-400 mb-1">Win Rate</p>
+              <p className="text-lg font-semibold">{(result.winRate * 100).toFixed(1)}%</p>
+            </div>
+            <div className="bg-white/5 rounded p-3 text-center">
+              <p className="text-xs text-gray-400 mb-1">Max Drawdown</p>
+              <p className="text-lg font-semibold">{(result.maxDrawdown * 100).toFixed(2)}%</p>
+            </div>
+          </div>
+
+          {result.trades.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm text-left">
+                <thead>
+                  <tr className="text-gray-400 border-b border-white/10">
+                    <th className="pb-2 pr-4">Time</th>
+                    <th className="pb-2">PnL</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.trades.map((t, i) => (
+                    <tr key={i} className="border-b border-white/5">
+                      <td className="py-1 pr-4">{t.time}</td>
+                      <td className={`py-1 ${t.pnl >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                        {t.pnl >= 0 ? '+' : ''}{t.pnl.toFixed(4)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      ) : (
+        !loading && (
+          <p className="text-gray-400">
+            Simulated results, win rate, drawdown and trades will appear here after running the simulation.
+          </p>
+        )
+      )}
     </div>
   )
 }

--- a/hooks/useCrossTabSync.ts
+++ b/hooks/useCrossTabSync.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+import { useWalletStore } from "@/store/useWalletStore";
+import { useThemeStore } from "@/store/useThemeStore";
+
+/**
+ * #265 – Cross-tab state synchronization.
+ * Listens to the native `storage` event (fired in OTHER tabs when localStorage
+ * changes) and re-hydrates the relevant Zustand store so the UI stays in sync
+ * without a page refresh.  Writing to the same store from the event handler
+ * does NOT emit another storage event in the same tab, so there is no loop.
+ */
+export function useCrossTabSync() {
+  useEffect(() => {
+    function handleStorage(e: StorageEvent) {
+      // Wallet store
+      if (e.key === "wallet-store" && e.newValue) {
+        try {
+          const { state } = JSON.parse(e.newValue);
+          useWalletStore.setState({
+            publicKey: state.publicKey ?? null,
+            isConnected: state.isConnected ?? false,
+            network: state.network ?? "TESTNET",
+          });
+        } catch {
+          // ignore malformed data
+        }
+      }
+
+      // Theme store
+      if (e.key === "stellar-theme" && e.newValue) {
+        try {
+          const { state } = JSON.parse(e.newValue);
+          if (state.theme === "dark" || state.theme === "light") {
+            useThemeStore.setState({ theme: state.theme });
+          }
+        } catch {
+          // ignore malformed data
+        }
+      }
+    }
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+}


### PR DESCRIPTION
## Summary

Implements four issues in a single PR.

### #265 – Cross-tab wallet & theme sync
- New `hooks/useCrossTabSync.ts` listens to the native `storage` event (fires only in *other* tabs) and re-hydrates `useWalletStore` / `useThemeStore`
- Mounted in `app/providers.tsx` — zero loop risk since writing to Zustand does not trigger `storage` in the same tab

### #266 – Shareable deep link for signal comparisons
- Selected signal IDs encoded into `?ids=a,b,c` via `router.replace` on every selection change
- On mount, restores comparison from URL if store is empty; missing/invalid IDs skipped gracefully
- "Share Link" button copies `window.location.href` to clipboard with ✓ confirmation

### #267 – Backtest result export
- **Export CSV** and **Export JSON** buttons added to `BacktestTool`; both disabled until results exist
- Exports include input params (from/to/signals/slippage/fee) alongside results — self-describing
- Full results display added: totalReturn, winRate, maxDrawdown, trades table

### #268 – Route-level dynamic imports
Converted to `next/dynamic` with `ssr: false` and skeleton loading fallbacks:
- `BacktestTool` → `app/backtest-sim`
- `ComparisonCard`, `ComparisonChart`, `AddSignalPanel` → `app/compare`
- `PortfolioAllocationChart`, `PnLWidget`, `PerformanceDashboard` → `app/analytics`
- `TaxReportingTool` → `app/tax-report`

## Closes
Closes #265
Closes #266
Closes #267
Closes #268