### PR TITLE
Add undo flows for destructive signal actions

### DIFF
--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -31,10 +31,10 @@ import { MiniChart } from "./chart/MiniChart";
 import { PremiumSignalBadge } from "@/components/PremiumSignalBadge";
 import { ProviderRatingBadge } from "@/components/ProviderRatingBadge";
 import { useDemoModeStore } from "@/store/useDemoModeStore";
-import { useBookmarkStore } from "@/store/useBookmarkStore";
+import { useBookmarkActions } from "@/hooks/useBookmarkActions";
 import { usePriceFormat } from "@/hooks/usePriceFormat";
 import { useSignalPrice } from "@/hooks/useSignalPrice";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { Signal as ApiSignal } from "@/lib/api";
 
 interface ROIPoint {
@@ -50,11 +50,12 @@ interface SignalCardProps {
   projectedTarget?: number;
   roiHistory?: ROIPoint[];
   analysis?: string;
-  action?: "BUY" | "SELL";
+  action?: "BUY" | "SELL" | "HOLD";
   timestamp?: Date;
   providerStake?: number;
   providerReputation?: number;
   providerName?: string;
+  signalId?: string;
   isPremium?: boolean;
   hasAccess?: boolean;
   requiredStake?: number;
@@ -62,6 +63,7 @@ interface SignalCardProps {
   portfolioBalance?: number;
   onTrade?: (pair: string, price: number) => void;
   onPass?: () => void;
+  showPassAction?: boolean;
 }
 
 const DEFAULT_ROI: ROIPoint[] = [
@@ -92,6 +94,7 @@ export function SignalCard({
   providerStake,
   providerReputation,
   providerName,
+  signalId: signalIdProp,
   isPremium = false,
   hasAccess = true,
   requiredStake = 1000,
@@ -99,8 +102,10 @@ export function SignalCard({
   portfolioBalance,
   onTrade,
   onPass,
+  showPassAction = true,
 }: SignalCardProps) {
   const [dismissed, setDismissed] = useState(false);
+  const [dismissPending, setDismissPending] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
   const [copiedFeedback, setCopiedFeedback] = useState(false);
@@ -113,6 +118,8 @@ export function SignalCard({
   const executingRef = useRef(false);
   const shareMenuRef = useRef<HTMLDivElement>(null);
   const hasVibratedRef = useRef(false);
+  const dismissTimerRef = useRef<number | null>(null);
+  const { addBookmark, removeBookmark, hasBookmark } = useBookmarkActions();
 
   const x = useMotionValue(0);
   const rotate = useTransform(x, [-300, 300], [-18, 18]);
@@ -121,10 +128,7 @@ export function SignalCard({
   const passOpacity = useTransform(x, [-20, -SWIPE_THRESHOLD], [0, 1]);
 
   const { price, flash, relativeTime } = useSignalPrice(3000);
-  const bookmarks = useBookmarkStore((state) => state.bookmarks);
-  const toggleBookmark = useBookmarkStore((state) => state.toggleBookmark);
-
-  const signalId = signalData?.id ?? pair ?? "signal-unknown";
+  const signalId = signalIdProp ?? signalData?.id ?? pair ?? "signal-unknown";
   const signalPair = pair ?? `${signalData?.asset ?? "XLM"}/USDC`;
   const signalAction = signalData?.action ?? action;
   const signalConfidence = signalData?.confidence ?? confidence;
@@ -133,8 +137,10 @@ export function SignalCard({
     : timestamp;
   const signalProvider =
     providerName ?? signalData?.providerName ?? signalData?.providerId ?? signalData?.asset ?? "Provider";
+  const badgeSignal =
+    signalAction === "BUY" ? "BUY" : signalAction === "SELL" ? "SELL" : "NEUTRAL";
 
-  const isBookmarked = bookmarks.includes(signalId);
+  const isBookmarked = hasBookmark(signalId);
   const bookmarkedLabel = isBookmarked ? "Remove bookmark" : "Bookmark signal";
 
   const currentPrice = executionPrice;
@@ -177,19 +183,51 @@ export function SignalCard({
     }
   }, [showShareMenu]);
 
+  useEffect(() => {
+    return () => {
+      if (dismissTimerRef.current !== null) {
+        window.clearTimeout(dismissTimerRef.current);
+      }
+    };
+  }, []);
+
   if (loading) return <TradeSkeleton />;
 
   const roi = (((projectedTarget - executionPrice) / executionPrice) * 100).toFixed(2);
   const isPositive = parseFloat(roi) >= 0;
 
   function handlePass() {
+    if (!showPassAction || dismissPending || dismissed) return;
     setActionAnnouncement(`Passed on ${signalAction} signal for ${signalPair}`);
-    setDismissed(true);
-    onPass?.();
+    setDismissPending(true);
+    if (dismissTimerRef.current !== null) {
+      window.clearTimeout(dismissTimerRef.current);
+    }
+    dismissTimerRef.current = window.setTimeout(() => {
+      setDismissPending(false);
+      setDismissed(true);
+      onPass?.();
+      dismissTimerRef.current = null;
+    }, 4500);
+    toast.info("Signal dismissed", {
+      description: `${signalPair} will disappear in a few seconds unless you undo it.`,
+      duration: 4500,
+      action: {
+        label: "Undo",
+        onClick: () => {
+          if (dismissTimerRef.current !== null) {
+            window.clearTimeout(dismissTimerRef.current);
+            dismissTimerRef.current = null;
+          }
+          setDismissPending(false);
+          setActionAnnouncement(`Restored ${signalAction} signal for ${signalPair}`);
+        },
+      },
+    });
   }
 
   function handleExecuteTrade() {
-    if (executingRef.current) return;
+    if (executingRef.current || dismissPending || dismissed) return;
     executingRef.current = true;
     setActionAnnouncement(`Opening trade modal for ${signalAction} ${signalPair}`);
     setModalOpen(true);
@@ -212,7 +250,7 @@ export function SignalCard({
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "ArrowLeft") {
+    if (e.key === "ArrowLeft" && showPassAction) {
       e.preventDefault();
       handlePass();
     } else if (e.key === "ArrowRight" || e.key === "Enter" || e.key === " ") {
@@ -259,9 +297,10 @@ export function SignalCard({
     ) {
       handleExecuteTrade();
     } else if (
-      offsetX < -SWIPE_THRESHOLD ||
-      (offsetX < -SWIPE_THRESHOLD * 0.4 && velocityX < -VELOCITY_THRESHOLD) ||
-      (fastSwipe && velocityX < 0)
+      showPassAction &&
+      (offsetX < -SWIPE_THRESHOLD ||
+        (offsetX < -SWIPE_THRESHOLD * 0.4 && velocityX < -VELOCITY_THRESHOLD) ||
+        (fastSwipe && velocityX < 0))
     ) {
       handlePass();
     }
@@ -285,11 +324,12 @@ export function SignalCard({
           dragConstraints={{ left: -180, right: 180 }}
           dragElastic={0.15}
           dragTransition={{ bounceStiffness: 600, bounceDamping: 22 }}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-          exit={{ x: 0, opacity: 0, scale: 0.85, transition: { duration: 0.25 } }}
-          whileTap={{ cursor: "grabbing" }}
-        >
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            exit={{ x: 0, opacity: 0, scale: 0.85, transition: { duration: 0.25 } }}
+            whileTap={{ cursor: "grabbing" }}
+            aria-disabled={dismissPending}
+          >
           <motion.div
             className="pointer-events-none absolute inset-0 z-10 flex items-center justify-start rounded-2xl border-2 border-green-500 bg-green-500/10 pl-6"
             style={{ opacity: tradeOpacity }}
@@ -300,15 +340,17 @@ export function SignalCard({
             </span>
           </motion.div>
 
-          <motion.div
-            className="pointer-events-none absolute inset-0 z-10 flex items-center justify-end rounded-2xl border-2 border-red-500 bg-red-500/10 pr-6"
-            style={{ opacity: passOpacity }}
-            aria-hidden="true"
-          >
-            <span className="flex items-center gap-1.5 rounded-lg bg-red-500 px-3 py-1.5 text-sm font-bold text-white shadow">
-              <X size={15} /> PASS
-            </span>
-          </motion.div>
+          {showPassAction && (
+            <motion.div
+              className="pointer-events-none absolute inset-0 z-10 flex items-center justify-end rounded-2xl border-2 border-red-500 bg-red-500/10 pr-6"
+              style={{ opacity: passOpacity }}
+              aria-hidden="true"
+            >
+              <span className="flex items-center gap-1.5 rounded-lg bg-red-500 px-3 py-1.5 text-sm font-bold text-white shadow">
+                <X size={15} /> PASS
+              </span>
+            </motion.div>
+          )}
 
           {/* ARIA live region — announces pass/trade actions to screen readers */}
           <div
@@ -328,7 +370,7 @@ export function SignalCard({
             tabIndex={0}
             onKeyDown={handleKeyDown}
             role="article"
-            aria-label={`${signalAction} signal for ${signalPair} at ${executionPrice} with ${signalConfidence}% confidence. Press Enter or right arrow to trade, left arrow to pass.`}
+            aria-label={`${signalAction} signal for ${signalPair} at ${executionPrice} with ${signalConfidence}% confidence. Press Enter or right arrow to trade${showPassAction ? ", left arrow to pass" : ""}.`}
           >
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex flex-col gap-2">
@@ -357,10 +399,17 @@ export function SignalCard({
               <div className="flex items-center gap-2">
                 <button
                   type="button"
-                  onClick={() => toggleBookmark(signalId)}
+                  onClick={() => {
+                    if (isBookmarked) {
+                      removeBookmark(signalId, signalPair);
+                    } else {
+                      addBookmark(signalId);
+                    }
+                  }}
                   aria-label={bookmarkedLabel}
+                  disabled={dismissPending || dismissed}
                   className={cn(
-                    "rounded-full p-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+                    "rounded-full p-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60",
                     isBookmarked ? "bg-sky-500/15 text-sky-300" : "bg-white/5 text-slate-300 hover:bg-white/10"
                   )}
                 >
@@ -397,7 +446,7 @@ export function SignalCard({
                     </div>
                   )}
                 </div>
-                <SignalBadge signal={signalAction} />
+                <SignalBadge signal={badgeSignal} />
               </div>
             </div>
 
@@ -517,23 +566,27 @@ export function SignalCard({
             </div>
 
             <div className="flex gap-2 pt-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handlePass}
-                className="flex-1"
-                aria-label={`Pass on ${signalAction} signal for ${signalPair}`}
-              >
-                <X size={16} className="mr-1" />
-                Pass
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleExecuteTrade}
-                disabled={modalOpen || (isPremium && !hasAccess) || !!conflictReason}
-                className="flex-1 active:scale-95"
-                aria-label={`Execute trade: ${signalAction} signal for ${signalPair} at ${executionPrice}${isDemoMode ? " (demo)" : ""}${isPremium && !hasAccess ? " (locked — stake required)" : ""}${conflictReason ? " (unavailable — signal conflict)" : ""}`}
-              >
+              {showPassAction && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handlePass}
+                  className="flex-1"
+                  disabled={dismissPending || dismissed}
+                  aria-label={`Pass on ${signalAction} signal for ${signalPair}`}
+                >
+                  <X size={16} className="mr-1" />
+                  Pass
+                </Button>
+              )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleExecuteTrade}
+                  disabled={modalOpen || (isPremium && !hasAccess) || !!conflictReason || dismissPending || dismissed}
+                  className="flex-1 active:scale-95"
+                  aria-label={`Execute trade: ${signalAction} signal for ${signalPair} at ${executionPrice}${isDemoMode ? " (demo)" : ""}${isPremium && !hasAccess ? " (locked — stake required)" : ""}${conflictReason ? " (unavailable — signal conflict)" : ""}`}
+                >
                 <Zap size={16} className="mr-1" />
                 {isDemoMode ? "Demo Trade" : "Execute Trade"}
               </Button>

--- a/components/comparison/ComparisonCard.tsx
+++ b/components/comparison/ComparisonCard.tsx
@@ -4,7 +4,7 @@ import { X, TrendingUp, TrendingDown, Bookmark, BookmarkCheck } from "lucide-rea
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Signal } from "@/lib/api";
-import { useBookmarkStore } from "@/store/useBookmarkStore";
+import { useBookmarkActions } from "@/hooks/useBookmarkActions";
 
 interface ComparisonCardProps {
   signal: Signal;
@@ -22,8 +22,8 @@ const METRIC_LABELS: Record<string, string> = {
 };
 
 export function ComparisonCard({ signal, onRemove, hiddenMetrics, bestValues }: ComparisonCardProps) {
-  const { bookmarks, toggleBookmark } = useBookmarkStore();
-  const isBookmarked = bookmarks.includes(signal.id);
+  const { hasBookmark, addBookmark, removeBookmark } = useBookmarkActions();
+  const isBookmarked = hasBookmark(signal.id);
   const isBuy = signal.action === "BUY";
 
   const metrics = [
@@ -92,7 +92,13 @@ export function ComparisonCard({ signal, onRemove, hiddenMetrics, bestValues }: 
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => toggleBookmark(signal.id)}
+          onClick={() => {
+            if (isBookmarked) {
+              removeBookmark(signal.id, signal.asset);
+            } else {
+              addBookmark(signal.id);
+            }
+          }}
           className={cn("w-full gap-2 text-xs", isBookmarked ? "text-yellow-400" : "text-gray-400")}
         >
           {isBookmarked ? <BookmarkCheck className="h-3.5 w-3.5" /> : <Bookmark className="h-3.5 w-3.5" />}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -59,14 +59,28 @@ export function ToastProvider() {
                       {toast.description}
                     </p>
                   ) : null}
-                  {toast.link ? (
-                    <a
-                      href={toast.link.href}
-                      className="mt-1.5 inline-block text-xs font-medium underline underline-offset-2 hover:opacity-75 transition-opacity"
-                    >
-                      {toast.link.label} →
-                    </a>
-                  ) : null}
+                  <div className="mt-1.5 flex flex-wrap items-center gap-2 text-xs font-medium">
+                    {toast.link ? (
+                      <a
+                        href={toast.link.href}
+                        className="underline underline-offset-2 hover:opacity-75 transition-opacity"
+                      >
+                        {toast.link.label} →
+                      </a>
+                    ) : null}
+                    {toast.action ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          toast.action?.onClick();
+                          dismiss(toast.id);
+                        }}
+                        className="rounded-full border border-current/20 px-2.5 py-1 text-current hover:bg-current/10 transition-colors"
+                      >
+                        {toast.action.label}
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
 
                 <button

--- a/hooks/useBookmarkActions.ts
+++ b/hooks/useBookmarkActions.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "@/lib/toast";
+import { useBookmarkStore } from "@/store/useBookmarkStore";
+
+function showUndoToast({
+  title,
+  description,
+  undoLabel = "Undo",
+  onUndo,
+}: {
+  title: string;
+  description: string;
+  undoLabel?: string;
+  onUndo: () => void;
+}) {
+  let toastId = "";
+
+  toastId = toast.info(title, {
+    description,
+    duration: 4500,
+    action: {
+      label: undoLabel,
+      onClick: onUndo,
+    },
+  });
+
+  return toastId;
+}
+
+export function useBookmarkActions() {
+  const addBookmark = useBookmarkStore((state) => state.addBookmark);
+  const restoreBookmark = useBookmarkStore((state) => state.addBookmark);
+  const removeBookmark = useBookmarkStore((state) => state.removeBookmark);
+  const toggleBookmark = useBookmarkStore((state) => state.toggleBookmark);
+  const hasBookmark = useBookmarkStore((state) => state.hasBookmark);
+
+  const bookmark = useCallback(
+    (id: string) => {
+      addBookmark(id);
+      toast.success("Bookmarked", {
+        description: "Saved to your bookmark list.",
+        duration: 2500,
+      });
+    },
+    [addBookmark]
+  );
+
+  const unbookmark = useCallback(
+    (id: string, label: string) => {
+      removeBookmark(id);
+      const toastId = showUndoToast({
+        title: "Bookmark removed",
+        description: `${label} was removed from your saved signals.`,
+        onUndo: () => restoreBookmark(id),
+      });
+
+      return toastId;
+    },
+    [removeBookmark, restoreBookmark]
+  );
+
+  const toggleBookmarkWithUndo = useCallback(
+    (id: string, label: string) => {
+      if (hasBookmark(id)) {
+        return unbookmark(id, label);
+      }
+      bookmark(id);
+      return null;
+    },
+    [bookmark, hasBookmark, unbookmark]
+  );
+
+  return {
+    addBookmark: bookmark,
+    removeBookmark: unbookmark,
+    toggleBookmark: (id: string, label: string) => toggleBookmarkWithUndo(id, label),
+    hasBookmark,
+    directToggleBookmark: toggleBookmark,
+  };
+}

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,10 +1,11 @@
 import { DEFAULT_TOAST_DURATION, useToastStore } from "@/store/useToastStore";
-import type { ToastTone } from "@/store/useToastStore";
+import type { ToastAction, ToastTone } from "@/store/useToastStore";
 
 export interface ToastOptions {
   description?: string;
   duration?: number;
   link?: { href: string; label: string };
+  action?: ToastAction;
 }
 
 function showToast(tone: ToastTone, title: string, options?: ToastOptions) {
@@ -13,6 +14,7 @@ function showToast(tone: ToastTone, title: string, options?: ToastOptions) {
     title,
     description: options?.description,
     link: options?.link,
+    action: options?.action,
     duration: options?.duration ?? DEFAULT_TOAST_DURATION,
   });
 }
@@ -32,9 +34,33 @@ export function useToast() {
   const dismiss = useToastStore((state) => state.dismiss);
 
   return {
-    success: (title: string, options?: ToastOptions) => enqueue({ tone: "success", title, description: options?.description, link: options?.link, duration: options?.duration ?? DEFAULT_TOAST_DURATION }),
-    error: (title: string, options?: ToastOptions) => enqueue({ tone: "error", title, description: options?.description, link: options?.link, duration: options?.duration ?? DEFAULT_TOAST_DURATION }),
-    info: (title: string, options?: ToastOptions) => enqueue({ tone: "info", title, description: options?.description, link: options?.link, duration: options?.duration ?? DEFAULT_TOAST_DURATION }),
+    success: (title: string, options?: ToastOptions) =>
+      enqueue({
+        tone: "success",
+        title,
+        description: options?.description,
+        link: options?.link,
+        action: options?.action,
+        duration: options?.duration ?? DEFAULT_TOAST_DURATION,
+      }),
+    error: (title: string, options?: ToastOptions) =>
+      enqueue({
+        tone: "error",
+        title,
+        description: options?.description,
+        link: options?.link,
+        action: options?.action,
+        duration: options?.duration ?? DEFAULT_TOAST_DURATION,
+      }),
+    info: (title: string, options?: ToastOptions) =>
+      enqueue({
+        tone: "info",
+        title,
+        description: options?.description,
+        link: options?.link,
+        action: options?.action,
+        duration: options?.duration ?? DEFAULT_TOAST_DURATION,
+      }),
     dismiss,
   };
 }

--- a/store/__tests__/stores.test.ts
+++ b/store/__tests__/stores.test.ts
@@ -1,4 +1,5 @@
 import { useWalletStore } from "@/store/useWalletStore";
+import { useBookmarkStore } from "@/store/useBookmarkStore";
 import { useSignalStore, type Signal } from "@/store/useSignalStore";
 import {
   useTransactionStore,
@@ -93,6 +94,47 @@ describe("useSignalStore", () => {
     useSignalStore.getState().setQueue(SAMPLE_SIGNALS);
     useSignalStore.getState().setQueue([]);
     expect(useSignalStore.getState().queue).toHaveLength(0);
+  });
+});
+
+// ── useBookmarkStore ─────────────────────────────────────────────────────────
+
+describe("useBookmarkStore", () => {
+  beforeEach(() => {
+    useBookmarkStore.setState({
+      bookmarks: [],
+      hasBookmark: (id: string) => useBookmarkStore.getState().bookmarks.includes(id),
+      addBookmark: useBookmarkStore.getState().addBookmark,
+      removeBookmark: useBookmarkStore.getState().removeBookmark,
+      toggleBookmark: useBookmarkStore.getState().toggleBookmark,
+      setBookmarks: useBookmarkStore.getState().setBookmarks,
+      clearBookmarks: useBookmarkStore.getState().clearBookmarks,
+    });
+  });
+
+  it("adds and removes bookmarks", () => {
+    useBookmarkStore.getState().addBookmark("signal-1");
+    expect(useBookmarkStore.getState().bookmarks).toEqual(["signal-1"]);
+    useBookmarkStore.getState().removeBookmark("signal-1");
+    expect(useBookmarkStore.getState().bookmarks).toEqual([]);
+  });
+
+  it("toggleBookmark flips membership", () => {
+    useBookmarkStore.getState().toggleBookmark("signal-2");
+    expect(useBookmarkStore.getState().bookmarks).toEqual(["signal-2"]);
+    useBookmarkStore.getState().toggleBookmark("signal-2");
+    expect(useBookmarkStore.getState().bookmarks).toEqual([]);
+  });
+
+  it("setBookmarks deduplicates ids", () => {
+    useBookmarkStore.getState().setBookmarks(["signal-3", "signal-3", "signal-4"]);
+    expect(useBookmarkStore.getState().bookmarks).toEqual(["signal-3", "signal-4"]);
+  });
+
+  it("hasBookmark reflects current state", () => {
+    useBookmarkStore.getState().addBookmark("signal-5");
+    expect(useBookmarkStore.getState().hasBookmark("signal-5")).toBe(true);
+    expect(useBookmarkStore.getState().hasBookmark("signal-x")).toBe(false);
   });
 });
 

--- a/store/useBookmarkStore.ts
+++ b/store/useBookmarkStore.ts
@@ -3,20 +3,36 @@ import { persist } from "zustand/middleware";
 
 interface BookmarkState {
   bookmarks: string[];
+  hasBookmark: (id: string) => boolean;
+  addBookmark: (id: string) => void;
+  removeBookmark: (id: string) => void;
   toggleBookmark: (id: string) => void;
+  setBookmarks: (ids: string[]) => void;
   clearBookmarks: () => void;
 }
 
 export const useBookmarkStore = create<BookmarkState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       bookmarks: [],
+      hasBookmark: (id: string) => get().bookmarks.includes(id),
+      addBookmark: (id: string) =>
+        set((state) => ({
+          bookmarks: state.bookmarks.includes(id)
+            ? state.bookmarks
+            : [...state.bookmarks, id],
+        })),
+      removeBookmark: (id: string) =>
+        set((state) => ({
+          bookmarks: state.bookmarks.filter((bookmark) => bookmark !== id),
+        })),
       toggleBookmark: (id: string) =>
         set((state) => ({
           bookmarks: state.bookmarks.includes(id)
             ? state.bookmarks.filter((bookmark) => bookmark !== id)
             : [...state.bookmarks, id],
         })),
+      setBookmarks: (ids: string[]) => set({ bookmarks: [...new Set(ids)] }),
       clearBookmarks: () => set({ bookmarks: [] }),
     }),
     { name: "signal-bookmarks" }

--- a/store/useToastStore.ts
+++ b/store/useToastStore.ts
@@ -4,11 +4,17 @@ import { create } from "zustand";
 
 export type ToastTone = "success" | "error" | "info";
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface ToastMessage {
   id: string;
   title: string;
   description?: string;
   link?: { href: string; label: string };
+  action?: ToastAction;
   tone: ToastTone;
   duration: number;
 }
@@ -34,12 +40,10 @@ function generateToastId() {
 
 export const useToastStore = create<ToastState>((set, get) => ({
   toasts: [],
-  enqueue: ({ title, description, link, tone, duration = DEFAULT_TOAST_DURATION }) => {
+  enqueue: ({ title, description, link, action, tone, duration = DEFAULT_TOAST_DURATION }) => {
     const id = generateToastId();
     set((state) => ({
-      toasts: [...state.toasts, { id, title, description, link, tone, duration }].slice(
-        -MAX_VISIBLE_TOASTS
-      ),
+      toasts: [...state.toasts, { id, title, description, link, action, tone, duration }].slice(-MAX_VISIBLE_TOASTS),
     }));
 
     if (typeof window !== "undefined" && duration > 0) {


### PR DESCRIPTION
Description

Improve the user experience for reversible destructive actions by introducing a temporary Undo mechanism. When a user dismisses a signal from the feed or removes a bookmark, the action should not be finalized immediately. Instead, the UI should optimistically update and display a toast notification containing an Undo action, giving the user a short period to reverse the change.

If the user selects Undo before the toast expires, the application should fully restore the previous state, including returning the dismissed signal to the feed or reinstating the removed bookmark. If no action is taken before the timeout expires, the operation should be permanently finalized and behave exactly as it does today.

The implementation must support multiple simultaneous undoable actions, ensuring each dismissal or bookmark removal maintains its own independent timer and restoration state without affecting other pending actions. This provides a safer and more forgiving user experience while preserving existing functionality when the undo window lapses.
closes #243