### PR TITLE
docs: add JSDoc comments to all components/ui primitives

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -29,12 +29,53 @@ const buttonVariants = cva(
   }
 );
 
+/**
+ * Props for the {@link Button} component.
+ *
+ * Extends all native `<button>` attributes plus CVA variant props.
+ */
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
+  /**
+   * When `true`, the button renders its child element directly via Radix
+   * `<Slot>`, merging props onto the child instead of rendering a `<button>`.
+   * Useful for wrapping `<Link>` or other non-button elements with button styles.
+   *
+   * @default false
+   */
   asChild?: boolean;
 }
 
+/**
+ * Button — the primary interactive element used throughout the app.
+ *
+ * Supports multiple visual variants (`default`, `destructive`, `outline`,
+ * `secondary`, `ghost`, `link`) and sizes (`default`, `sm`, `lg`, `icon`).
+ * Inherits all native `<button>` HTML attributes and forwards a ref.
+ *
+ * @example
+ * // Default primary button
+ * <Button onClick={handleTrade}>Place Order</Button>
+ *
+ * @example
+ * // Destructive variant, small size
+ * <Button variant="destructive" size="sm">Cancel</Button>
+ *
+ * @example
+ * // Icon-only button
+ * <Button variant="ghost" size="icon" aria-label="Close">
+ *   <X className="h-4 w-4" />
+ * </Button>
+ *
+ * @example
+ * // Render as a Next.js Link (asChild)
+ * <Button asChild variant="link">
+ *   <Link href="/dashboard">Go to Dashboard</Link>
+ * </Button>
+ *
+ * @see {@link https://storybook.stellarswipe.dev/?path=/docs/ui-button--docs Storybook — Button}
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,6 +1,27 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+/**
+ * Card — a rounded surface container used to visually group related content.
+ *
+ * Renders a `<div>` with a border, background, and subtle shadow. Compose with
+ * {@link CardHeader} and {@link CardContent} to build structured card layouts,
+ * or supply arbitrary children directly.
+ *
+ * Accepts all standard `<div>` HTML attributes and forwards a ref.
+ *
+ * @example
+ * <Card>
+ *   <CardHeader>
+ *     <h3>Signal: XLM/USDC</h3>
+ *   </CardHeader>
+ *   <CardContent>
+ *     <p>Confidence: 82%</p>
+ *   </CardContent>
+ * </Card>
+ *
+ * @see {@link https://storybook.stellarswipe.dev/?path=/docs/ui-card--docs Storybook — Card}
+ */
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div
@@ -15,6 +36,18 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
 );
 Card.displayName = "Card";
 
+/**
+ * CardHeader — the top section of a {@link Card}, providing consistent
+ * padding and a vertical flex layout for title / subtitle content.
+ *
+ * Accepts all standard `<div>` HTML attributes and forwards a ref.
+ *
+ * @example
+ * <CardHeader>
+ *   <h3 className="font-semibold">Portfolio Summary</h3>
+ *   <p className="text-sm text-muted-foreground">Last updated 5 min ago</p>
+ * </CardHeader>
+ */
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div ref={ref} className={cn("flex flex-col gap-1.5 p-5 pb-3", className)} {...props} />
@@ -22,6 +55,20 @@ const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardHeader.displayName = "CardHeader";
 
+/**
+ * CardContent — the body section of a {@link Card} with horizontal and bottom
+ * padding. Place the primary content of the card here.
+ *
+ * Accepts all standard `<div>` HTML attributes and forwards a ref.
+ *
+ * @example
+ * <CardContent>
+ *   <dl className="space-y-1 text-sm">
+ *     <div><dt>Entry</dt><dd>$0.4821</dd></div>
+ *     <div><dt>Target</dt><dd>$0.55</dd></div>
+ *   </dl>
+ * </CardContent>
+ */
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div ref={ref} className={cn("px-5 pb-5", className)} {...props} />

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -21,6 +21,24 @@ export interface CopyButtonProps
  *
  * Works across browsers via the Clipboard API with a legacy execCommand
  * fallback (see useClipboard hook).
+ *
+ * @example
+ * // Standalone copy button with a custom label
+ * <CopyButton value={walletAddress} label="Copy address" />
+ *
+ * @example
+ * // Keep the "Copied!" state for 5 seconds
+ * <CopyButton value={txHash} label="Copy tx hash" resetDelay={5000} />
+ *
+ * @example
+ * // Inside a toolbar, icon-only appearance via className
+ * <CopyButton
+ *   value={apiKey}
+ *   label="Copy API key"
+ *   className="border-0 bg-transparent p-1"
+ * />
+ *
+ * @see {@link https://storybook.stellarswipe.dev/?path=/docs/ui-copybutton--docs Storybook — CopyButton}
  */
 const CopyButton = React.forwardRef<HTMLButtonElement, CopyButtonProps>(
   (

--- a/components/ui/copy-field.tsx
+++ b/components/ui/copy-field.tsx
@@ -17,8 +17,33 @@ export interface CopyFieldProps {
 }
 
 /**
- * CopyField — displays a truncated address/hash with an inline CopyButton.
- * Suitable for wallet addresses and transaction hashes.
+ * CopyField — displays a read-only address or hash with an inline
+ * {@link CopyButton}. Long values are truncated in the UI while the full
+ * string is always copied to the clipboard.
+ *
+ * Suitable for wallet addresses, transaction hashes, and any opaque token
+ * that users need to copy but rarely read character-by-character.
+ *
+ * @example
+ * // Wallet address with label, default truncation (8 chars each side)
+ * <CopyField
+ *   label="Wallet address"
+ *   value="GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+ * />
+ *
+ * @example
+ * // Transaction hash, show more characters
+ * <CopyField
+ *   label="Tx hash"
+ *   value="a1b2c3d4e5f6..."
+ *   truncateChars={12}
+ * />
+ *
+ * @example
+ * // Disable truncation to always show the full value
+ * <CopyField value={apiKey} truncate={false} />
+ *
+ * @see {@link https://storybook.stellarswipe.dev/?path=/docs/ui-copyfield--docs Storybook — CopyField}
  */
 export function CopyField({
   value,

--- a/components/ui/stop-loss-slider.tsx
+++ b/components/ui/stop-loss-slider.tsx
@@ -32,6 +32,33 @@ export interface StopLossSliderProps {
  * - Displays the corresponding price when entryPrice is provided
  * - ARIA attributes for screen readers
  * - Value persists while the parent keeps it in state
+ *
+ * @example
+ * // Controlled slider with derived stop-loss price
+ * const [stopLoss, setStopLoss] = React.useState(10);
+ *
+ * <StopLossSlider
+ *   value={stopLoss}
+ *   onChange={setStopLoss}
+ *   entryPrice={0.4821}
+ *   assetSymbol="XLM"
+ * />
+ *
+ * @example
+ * // Tighter range (1–25 %), step of 0.5
+ * <StopLossSlider
+ *   value={stopLoss}
+ *   onChange={setStopLoss}
+ *   min={1}
+ *   max={25}
+ *   step={0.5}
+ * />
+ *
+ * @example
+ * // Disabled while a trade is submitting
+ * <StopLossSlider value={stopLoss} onChange={setStopLoss} disabled={isSubmitting} />
+ *
+ * @see {@link https://storybook.stellarswipe.dev/?path=/docs/ui-stoplosslider--docs Storybook — StopLossSlider}
  */
 export function StopLossSlider({
   value,

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -17,6 +17,42 @@ const toneIcons: Record<ToastMessage["tone"], typeof CheckCircle2> = {
   info: Info,
 };
 
+/**
+ * ToastProvider — renders the app's global toast notification stack.
+ *
+ * Reads from `useToastStore` and renders animated toast cards in a fixed
+ * overlay. Toasts appear at the bottom of the screen on mobile and at the
+ * top-right on larger viewports. Each toast is dismissed via its close button
+ * or automatically after its configured `duration`.
+ *
+ * Three visual tones are supported:
+ * - `success` — green, confirms a completed action (e.g. trade submitted)
+ * - `error` — red, signals a failure (e.g. network error)
+ * - `info` — blue, communicates neutral information (e.g. demo mode active)
+ *
+ * Mount once in the app root (e.g. `app/layout.tsx`); do **not** nest
+ * multiple instances.
+ *
+ * Toast messages are queued via `useToastStore`:
+ * ```ts
+ * import { useToastStore } from "@/store/useToastStore";
+ *
+ * const { push } = useToastStore();
+ *
+ * // Success toast with optional description and link
+ * push({
+ *   tone: "success",
+ *   title: "Trade confirmed",
+ *   description: "Your XLM order was submitted.",
+ *   link: { href: "https://stellar.expert/...", label: "View on Explorer" },
+ * });
+ *
+ * // Error toast
+ * push({ tone: "error", title: "Network error", description: "Check your connection." });
+ * ```
+ *
+ * @see {@link https://storybook.stellarswipe.dev/?path=/docs/ui-toastprovider--docs Storybook — ToastProvider}
+ */
 export function ToastProvider() {
   const toasts = useToastStore((state) => state.toasts);
   const dismiss = useToastStore((state) => state.dismiss);


### PR DESCRIPTION
- button.tsx: document ButtonProps, variant/size props, asChild, and 4 usage examples
- card.tsx: document Card, CardHeader, CardContent with purpose and examples
- toast.tsx: document ToastProvider with tone values and push() usage example
- copy-field.tsx: expand JSDoc with 3 usage examples (label, truncateChars, truncate=false)
- copy-button.tsx: expand JSDoc with 3 usage examples (label, resetDelay, className)
- stop-loss-slider.tsx: add 3 usage examples (basic, custom range/step, disabled)

All components link to their Storybook story for further reference.
close #260