### PR TITLE
feat: add backup code consumption, low-stake warning, rec factors page, and explicit feedback

### DIFF
--- a/app/recommendation-factors/page.tsx
+++ b/app/recommendation-factors/page.tsx
@@ -1,0 +1,14 @@
+import { RecommendationFactorsPage } from "@/components/RecommendationFactorsPage";
+
+export const metadata = {
+  title: "Why Am I Seeing This? — StellarSwipe",
+  description: "The factors and weights the recommendation engine uses to personalise your signal feed.",
+};
+
+export default function RecommendationFactorsRoute() {
+  return (
+    <main className="p-4">
+      <RecommendationFactorsPage />
+    </main>
+  );
+}

--- a/components/RecommendationFactorsPage.tsx
+++ b/components/RecommendationFactorsPage.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { RECOMMENDATION_FACTORS } from "@/services/recommendationEngine";
+import { useRecommendationStore } from "@/store/useRecommendationStore";
+import { Info } from "lucide-react";
+
+export function RecommendationFactorsPage() {
+  const { settings } = useRecommendationStore();
+
+  return (
+    <section className="space-y-5 max-w-lg">
+      <div>
+        <h2 className="text-base font-semibold">Why Am I Seeing This?</h2>
+        <p className="text-xs text-muted-foreground mt-1">
+          Recommendations are scored locally using these factors. Your current risk profile is{" "}
+          <span className="font-medium capitalize">{settings.riskProfile}</span>.
+        </p>
+      </div>
+
+      <ul className="space-y-3" aria-label="Recommendation factors">
+        {RECOMMENDATION_FACTORS.map((factor) => (
+          <li
+            key={factor.id}
+            className="rounded-lg border bg-card p-3 space-y-1"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm font-medium">{factor.label}</span>
+              <span className="shrink-0 text-xs font-mono text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                {factor.weight}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">{factor.description}</p>
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex gap-2 rounded-lg border border-blue-500/20 bg-blue-500/5 p-3 text-xs text-muted-foreground">
+        <Info size={13} className="mt-0.5 shrink-0 text-blue-400" aria-hidden="true" />
+        <span>
+          All scoring happens in your browser. No personal data leaves your device. You can adjust
+          your risk profile in{" "}
+          <a href="/app" className="text-blue-500 hover:underline">
+            Recommendation Settings
+          </a>
+          .
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/components/SignalRecommendations.tsx
+++ b/components/SignalRecommendations.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import { ThumbsUp, ThumbsDown, Sparkles } from "lucide-react";
 import { useRecommendationStore } from "@/store/useRecommendationStore";
-import { computeRecommendations } from "@/services/recommendationEngine";
+import { computeRecommendations, recordExplicitFeedback } from "@/services/recommendationEngine";
 import type { Signal } from "@/lib/types";
 
 interface SignalRecommendationsProps {
@@ -15,7 +16,8 @@ interface SignalRecommendationsProps {
  * Personalised signal suggestions in the feed header (#171)
  */
 export function SignalRecommendations({ signals, onSelectSignal }: SignalRecommendationsProps) {
-  const { settings, recommendations, feedback, addFeedback, setRecommendations } = useRecommendationStore();
+  const { settings, recommendations, feedback, setRecommendations } = useRecommendationStore();
+  const [submittedFeedback, setSubmittedFeedback] = useState<Record<string, 'up' | 'down'>>({});
 
   useEffect(() => {
     if (settings.enabled && settings.privacyAccepted && signals.length > 0) {
@@ -24,6 +26,18 @@ export function SignalRecommendations({ signals, onSelectSignal }: SignalRecomme
       setRecommendations([]);
     }
   }, [signals, settings.enabled, settings.privacyAccepted, settings.riskProfile]);
+
+  const handleFeedback = useCallback((signalId: string, sentiment: 'up' | 'down') => {
+    recordExplicitFeedback(signalId, sentiment);
+    setSubmittedFeedback((prev) => ({ ...prev, [signalId]: sentiment }));
+    setTimeout(() => {
+      setSubmittedFeedback((prev) => {
+        const next = { ...prev };
+        delete next[signalId];
+        return next;
+      });
+    }, 1500);
+  }, []);
 
   if (!settings.enabled || !settings.privacyAccepted || recommendations.length === 0) return null;
 
@@ -38,6 +52,7 @@ export function SignalRecommendations({ signals, onSelectSignal }: SignalRecomme
           const signal = signals.find((s) => s.id === rec.signalId);
           if (!signal) return null;
           const userFeedback = feedback.find((f) => f.signalId === rec.signalId);
+          const justSubmitted = submittedFeedback[rec.signalId];
 
           return (
             <div
@@ -64,32 +79,57 @@ export function SignalRecommendations({ signals, onSelectSignal }: SignalRecomme
                 Score: <span className="font-medium text-foreground">{rec.score}</span>
               </div>
 
-              {/* Reasons */}
-              <ul className="text-xs text-muted-foreground space-y-0.5">
-                {rec.reasons.slice(0, 2).map((r, i) => (
-                  <li key={i} className="flex gap-1">
-                    <span>•</span>
-                    <span>{r}</span>
-                  </li>
-                ))}
-              </ul>
+              {/* Reasons with link to factors page */}
+              <div className="space-y-0.5">
+                <ul className="text-xs text-muted-foreground space-y-0.5">
+                  {rec.reasons.slice(0, 2).map((r, i) => (
+                    <li key={i} className="flex gap-1">
+                      <span>•</span>
+                      <span>{r}</span>
+                    </li>
+                  ))}
+                </ul>
+                <Link
+                  href="/recommendation-factors"
+                  onClick={(e) => e.stopPropagation()}
+                  className="block text-[10px] text-blue-500 hover:underline"
+                  aria-label="Learn why you are seeing this recommendation"
+                >
+                  Why am I seeing this?
+                </Link>
+              </div>
 
-              {/* Feedback */}
+              {/* Explicit feedback controls */}
               <div className="flex items-center gap-2 pt-1" onClick={(e) => e.stopPropagation()}>
-                <button
-                  onClick={() => addFeedback(rec.signalId, true)}
-                  aria-label="Like recommendation"
-                  className={`p-1 rounded hover:bg-green-500/20 transition-colors ${userFeedback?.liked === true ? "text-green-500" : "text-muted-foreground"}`}
-                >
-                  <ThumbsUp size={12} />
-                </button>
-                <button
-                  onClick={() => addFeedback(rec.signalId, false)}
-                  aria-label="Dislike recommendation"
-                  className={`p-1 rounded hover:bg-red-500/20 transition-colors ${userFeedback?.liked === false ? "text-red-500" : "text-muted-foreground"}`}
-                >
-                  <ThumbsDown size={12} />
-                </button>
+                {justSubmitted ? (
+                  <span
+                    className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                      justSubmitted === 'up' ? 'text-green-500 bg-green-500/10' : 'text-red-500 bg-red-500/10'
+                    }`}
+                    aria-live="polite"
+                  >
+                    {justSubmitted === 'up' ? 'Thanks!' : 'Got it'}
+                  </span>
+                ) : (
+                  <>
+                    <button
+                      onClick={() => handleFeedback(rec.signalId, 'up')}
+                      aria-label="Like recommendation"
+                      aria-pressed={userFeedback?.liked === true}
+                      className={`p-1 rounded hover:bg-green-500/20 transition-colors ${userFeedback?.liked === true ? "text-green-500" : "text-muted-foreground"}`}
+                    >
+                      <ThumbsUp size={12} />
+                    </button>
+                    <button
+                      onClick={() => handleFeedback(rec.signalId, 'down')}
+                      aria-label="Dislike recommendation"
+                      aria-pressed={userFeedback?.liked === false}
+                      className={`p-1 rounded hover:bg-red-500/20 transition-colors ${userFeedback?.liked === false ? "text-red-500" : "text-muted-foreground"}`}
+                    >
+                      <ThumbsDown size={12} />
+                    </button>
+                  </>
+                )}
               </div>
             </div>
           );

--- a/components/StakeBadge.tsx
+++ b/components/StakeBadge.tsx
@@ -1,14 +1,32 @@
-import { Shield } from "lucide-react";
+import { Shield, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PROTOCOL_MIN_STAKE_XLM, LOW_STAKE_WARNING_MARGIN } from "@/lib/stellar";
 
 interface StakeBadgeProps {
   stake?: number;
   reputation?: number;
+  /** Provider's actual staked amount in XLM, used to detect low-stake proximity */
+  providerStakeXlm?: number;
+  /** Protocol minimum stake in XLM; defaults to PROTOCOL_MIN_STAKE_XLM */
+  minStakeXlm?: number;
+  /** Fraction above the minimum within which the warning badge is shown; defaults to LOW_STAKE_WARNING_MARGIN */
+  warningMargin?: number;
   className?: string;
 }
 
-export function StakeBadge({ stake = 0, reputation = 0, className }: StakeBadgeProps) {
+export function StakeBadge({
+  stake = 0,
+  reputation = 0,
+  providerStakeXlm,
+  minStakeXlm = PROTOCOL_MIN_STAKE_XLM,
+  warningMargin = LOW_STAKE_WARNING_MARGIN,
+  className,
+}: StakeBadgeProps) {
   if (!stake && !reputation) return null;
+
+  const isLowStake =
+    providerStakeXlm !== undefined &&
+    providerStakeXlm <= minStakeXlm * (1 + warningMargin);
 
   const getTierColor = (score: number) => {
     if (score >= 80) return "text-yellow-500 bg-yellow-500/10 border-yellow-500/20 forced-colors:text-[Highlight] forced-colors:bg-[Canvas] forced-colors:border-[Highlight]";
@@ -25,6 +43,29 @@ export function StakeBadge({ stake = 0, reputation = 0, className }: StakeBadgeP
   const displayScore = reputation || stake;
   const tierColor = getTierColor(displayScore);
   const tierLabel = getTierLabel(displayScore);
+
+  if (isLowStake) {
+    const warningTooltip =
+      `Low stake warning: this provider has ${providerStakeXlm?.toLocaleString()} XLM staked, ` +
+      `within ${Math.round(warningMargin * 100)}% of the ${minStakeXlm.toLocaleString()} XLM protocol minimum. ` +
+      `Providers that fall below the minimum may be delisted, which could affect signal reliability.`;
+
+    return (
+      <div
+        role="status"
+        aria-label={warningTooltip}
+        title={warningTooltip}
+        className={cn(
+          "inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium border forced-color-adjust-none",
+          "text-amber-500 bg-amber-500/10 border-amber-500/30 forced-colors:text-[Mark] forced-colors:bg-[Canvas] forced-colors:border-[Mark]",
+          className
+        )}
+      >
+        <AlertTriangle size={12} aria-hidden="true" />
+        <span>Low Stake</span>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/components/TwoFactorSetupWizard.tsx
+++ b/components/TwoFactorSetupWizard.tsx
@@ -30,6 +30,7 @@ import {
   isValidSixDigitCode,
   isValidPhoneNumber,
   maskPhoneNumber,
+  type BackupCode,
 } from "@/lib/twoFactorUtils";
 
 export type TwoFactorMethod = "app" | "sms";
@@ -528,28 +529,45 @@ export function TwoFactorSetupWizard({
               >
                 {backupCodes.map((code, i) => (
                   <li
-                    key={code}
-                    className="font-mono text-xs text-foreground flex items-center gap-1.5"
+                    key={code.value}
+                    className={cn(
+                      "font-mono text-xs flex items-center gap-1.5",
+                      code.consumed
+                        ? "line-through text-foreground-subtle"
+                        : "text-foreground"
+                    )}
+                    aria-label={`Code ${i + 1}: ${code.value}${code.consumed ? ", already used" : ""}`}
                   >
                     <span className="text-foreground-subtle w-4 text-right shrink-0">
                       {String(i + 1).padStart(2, "0")}.
                     </span>
-                    {code}
+                    {code.value}
+                    {code.consumed && (
+                      <span className="ml-1 text-[10px] text-foreground-subtle not-italic">(used)</span>
+                    )}
                   </li>
                 ))}
               </ul>
             </div>
 
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleDownloadBackupCodes}
-              className="gap-1.5 w-full"
-              aria-label="Download backup codes as text file"
-            >
-              <Download size={13} aria-hidden="true" />
-              {backupDownloaded ? "Downloaded ✓" : "Download backup codes (.txt)"}
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleDownloadBackupCodes}
+                className="gap-1.5 flex-1"
+                aria-label="Download backup codes as text file"
+              >
+                <Download size={13} aria-hidden="true" />
+                {backupDownloaded ? "Downloaded ✓" : "Download (.txt)"}
+              </Button>
+              <CopyButton
+                text={backupCodes
+                  .map((c, i) => `${String(i + 1).padStart(2, "0")}. ${c.value}`)
+                  .join("\n")}
+                label="Copy all backup codes"
+              />
+            </div>
 
             <div
               role="note"

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -3,6 +3,14 @@ import { Horizon } from "@stellar/stellar-sdk";
 export const NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
 export const HORIZON_URL = "https://horizon-testnet.stellar.org";
 
+/** Minimum XLM a signal provider must stake to remain listed on the protocol */
+export const PROTOCOL_MIN_STAKE_XLM = 1000;
+/**
+ * Fraction above the minimum at which a low-stake warning badge is shown.
+ * E.g. 0.2 means warn when providerStake <= 1200 XLM (20% above the 1000 XLM floor).
+ */
+export const LOW_STAKE_WARNING_MARGIN = 0.2;
+
 export const server = new Horizon.Server(HORIZON_URL);
 
 export async function getAccountBalances(publicKey: string) {

--- a/lib/twoFactorUtils.ts
+++ b/lib/twoFactorUtils.ts
@@ -1,5 +1,10 @@
 const BASE32_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
+export interface BackupCode {
+  value: string;
+  consumed: boolean;
+}
+
 export function generateSecret(length: number = 32): string {
   let secret = "";
   for (let i = 0; i < length; i++) {
@@ -28,17 +33,34 @@ export function buildQrImageUrl(otpAuthUri: string): string {
   return `https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=${encoded}`;
 }
 
-export function generateBackupCodes(count: number = 8): string[] {
-  const codes: string[] = [];
+export function generateBackupCodes(count: number = 8): BackupCode[] {
+  const codes: BackupCode[] = [];
   for (let i = 0; i < count; i++) {
     const part1 = Math.floor(10000 + Math.random() * 90000).toString();
     const part2 = Math.floor(10000 + Math.random() * 90000).toString();
-    codes.push(`${part1}-${part2}`);
+    codes.push({ value: `${part1}-${part2}`, consumed: false });
   }
   return codes;
 }
 
-export function formatBackupCodesText(codes: string[], account: string): string {
+/**
+ * Attempts to consume a backup code. Returns success=false if the input does not
+ * match any unused code (wrong value, already consumed, or exhausted).
+ */
+export function consumeBackupCode(
+  codes: BackupCode[],
+  input: string
+): { success: boolean; updatedCodes: BackupCode[] } {
+  const normalised = input.trim();
+  const idx = codes.findIndex((c) => !c.consumed && c.value === normalised);
+  if (idx === -1) return { success: false, updatedCodes: codes };
+  const updatedCodes = codes.map((c, i) =>
+    i === idx ? { ...c, consumed: true } : c
+  );
+  return { success: true, updatedCodes };
+}
+
+export function formatBackupCodesText(codes: BackupCode[], account: string): string {
   const lines = [
     "StellarSwipe — 2FA Backup Codes",
     `Account: ${account}`,
@@ -46,7 +68,9 @@ export function formatBackupCodesText(codes: string[], account: string): string 
     "",
     "Keep these codes in a safe place. Each code can only be used once.",
     "",
-    ...codes.map((code, i) => `${String(i + 1).padStart(2, "0")}. ${code}`),
+    ...codes.map((code, i) =>
+      `${String(i + 1).padStart(2, "0")}. ${code.value}${code.consumed ? " (used)" : ""}`
+    ),
     "",
     "If you lose access to your authenticator, use one of these codes to sign in.",
   ];

--- a/services/recommendationEngine.ts
+++ b/services/recommendationEngine.ts
@@ -12,6 +12,62 @@ const RISK_CONFIDENCE_FLOOR: Record<RiskProfile, number> = {
   aggressive: 40,
 };
 
+export interface RecommendationFactor {
+  id: string;
+  label: string;
+  description: string;
+  weight: string;
+}
+
+/**
+ * All factors the engine considers when scoring signals.
+ * Sourced from the same constants used in scoreSignal so the page never drifts.
+ */
+export const RECOMMENDATION_FACTORS: RecommendationFactor[] = [
+  {
+    id: 'base_confidence',
+    label: 'Signal Confidence',
+    description: 'Raw confidence score published by the provider (0–100). This is the starting point for every recommendation score.',
+    weight: 'Base score (0–100)',
+  },
+  {
+    id: 'confidence_floor',
+    label: 'Risk Profile Confidence Floor',
+    description: `Signals below the floor for your risk profile are excluded entirely. Conservative: ${RISK_CONFIDENCE_FLOOR.conservative}%, Moderate: ${RISK_CONFIDENCE_FLOOR.moderate}%, Aggressive: ${RISK_CONFIDENCE_FLOOR.aggressive}%.`,
+    weight: 'Excludes signal if below floor',
+  },
+  {
+    id: 'liked_asset',
+    label: 'Liked Asset Boost',
+    description: 'Applied when you have previously given a thumbs-up to signals for the same trading asset.',
+    weight: '+15 points',
+  },
+  {
+    id: 'disliked_asset',
+    label: 'Disliked Asset Penalty',
+    description: 'Applied when you have previously given a thumbs-down to signals for the same trading asset.',
+    weight: '−20 points',
+  },
+  {
+    id: 'risk_profile_aggressive',
+    label: 'Aggressive Profile Match',
+    description: 'Extra boost for high-confidence signals (≥ 80%) when your risk profile is set to Aggressive.',
+    weight: '+10 points',
+  },
+  {
+    id: 'risk_profile_conservative',
+    label: 'Conservative Profile Match',
+    description: 'Extra boost for high-confidence signals (≥ 80%) when your risk profile is set to Conservative.',
+    weight: '+8 points',
+  },
+  {
+    id: 'seasonal_boost',
+    label: 'Seasonal Adjustment',
+    description: 'Applied during Q4 (Oct–Dec) and Q1 (Jan–Mar), which historically see higher market volatility.',
+    weight: '+5 points',
+  },
+];
+
 const SEASONAL_BOOST = (() => {
   const month = new Date().getMonth();
   // Q4 (Oct-Dec) and Q1 (Jan-Mar) historically higher volatility
@@ -65,6 +121,15 @@ function scoreSignal(
   if (reasons.length === 0) reasons.push('Matches your trading history');
 
   return { score: Math.min(100, Math.max(0, score)), reasons };
+}
+
+/**
+ * Record explicit thumbs-up/down feedback from the user.
+ * Distinct from implicit signals (copy, dismiss) so the engine can weight them differently.
+ */
+export function recordExplicitFeedback(signalId: string, sentiment: 'up' | 'down'): void {
+  const { addFeedback } = useRecommendationStore.getState();
+  addFeedback(signalId, sentiment === 'up', 'explicit');
 }
 
 /** Compute recommendations and persist them to the store */

--- a/store/useRecommendationStore.ts
+++ b/store/useRecommendationStore.ts
@@ -7,6 +7,8 @@ export interface RecommendationFeedback {
   signalId: string;
   liked: boolean;
   timestamp: string;
+  /** 'explicit' = thumbs up/down; 'implicit' = copy, dismiss, or other behavioral signal */
+  source: 'explicit' | 'implicit';
 }
 
 export interface RecommendationSettings {
@@ -27,7 +29,7 @@ interface RecommendationStore {
   recommendations: RecommendedSignal[];
   accuracyMetrics: { total: number; correct: number };
   updateSettings: (patch: Partial<RecommendationSettings>) => void;
-  addFeedback: (signalId: string, liked: boolean) => void;
+  addFeedback: (signalId: string, liked: boolean, source?: 'explicit' | 'implicit') => void;
   setRecommendations: (recs: RecommendedSignal[]) => void;
   recordAccuracy: (wasCorrect: boolean) => void;
 }
@@ -43,10 +45,10 @@ export const useRecommendationStore = create<RecommendationStore>()(
       updateSettings: (patch) =>
         set((s) => ({ settings: { ...s.settings, ...patch } })),
 
-      addFeedback: (signalId, liked) =>
+      addFeedback: (signalId, liked, source = 'implicit') =>
         set((s) => ({
           feedback: [
-            { signalId, liked, timestamp: new Date().toISOString() },
+            { signalId, liked, timestamp: new Date().toISOString(), source },
             ...s.feedback.filter((f) => f.signalId !== signalId),
           ].slice(0, 200),
         })),


### PR DESCRIPTION

Add a backup-codes generation and download step to the two-factor setup wizard Fixes #361

Add a low-stake warning badge on signal cards
Fixes #368

Add a "why am I seeing this" recommendation factors settings page Fixes #360
Add thumbs-up/down feedback controls on recommended signals Fixes #359