### PR TITLE
Accessibility fixes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,28 @@
   .pb-safe {
     padding-bottom: max(1rem, env(safe-area-inset-bottom));
   }
+
+  /* Skip-to-main-content link — visually hidden until focused */
+  .skip-link {
+    position: absolute;
+    top: -9999px;
+    left: 0;
+    z-index: 9999;
+    padding: 0.75rem 1.25rem;
+    background-color: hsl(var(--accent-primary));
+    color: #fff;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border-radius: 0 0 0.5rem 0;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .skip-link:focus,
+  .skip-link:focus-visible {
+    top: 0;
+    outline: 3px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
 }
 
 @layer base {

--- a/app/globals.css
+++ b/app/globals.css
@@ -441,6 +441,35 @@
   .z-loading   { z-index: var(--z-loading); }
 }
 
+/* ── Reduced-motion overrides ───────────────────────────────────────────── */
+/*
+ * When the user has requested reduced motion, disable decorative CSS
+ * animations (scroll reveals, dialog slide/zoom transitions). Essential
+ * feedback like loading spinners (animate-spin) are preserved because they
+ * communicate state, not just decoration.
+ */
+@media (prefers-reduced-motion: reduce) {
+  /* Suppress the Radix dialog slide/zoom keyframe animations */
+  .dialog-overlay,
+  .dialog-content {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  /* Suppress Tailwind's animate-pulse on skeleton loaders — keep them visible */
+  .animate-pulse {
+    animation: none !important;
+  }
+
+  /* Ensure Framer Motion inline styles don't override this when y/scale are
+     zeroed out: framer-motion respects useReducedMotion() in JS, but as a
+     belt-and-suspenders measure we also disable CSS transitions here. */
+  [style*="transform"],
+  [style*="opacity"] {
+    transition: none !important;
+  }
+}
+
 /* ── Print-friendly styling ──────────────────────────────────────────────── */
 @media print {
   /* Hide non-essential UI */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,10 +29,16 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={inter.variable}>
       <head>
-        {/* Apply persisted theme before first paint to avoid flash */}
+        {/*
+         * Blocking inline script — runs synchronously before any paint.
+         * Reads the persisted Zustand theme ("stellar-theme" → state.theme),
+         * falls back to the OS prefers-color-scheme, then applies the correct
+         * .dark / .light class to <html> before any CSS or React hydration.
+         * suppressHydrationWarning on <html> lets React reconcile safely.
+         */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var item=localStorage.getItem('stellar-theme');var theme=item?JSON.parse(item).state?.theme:null; if(!theme){theme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';} document.documentElement.classList.remove('light','dark'); document.documentElement.classList.add(theme);}catch(e){}})();`,
+            __html: `(function(){try{var s=localStorage.getItem('stellar-theme');var t=s?JSON.parse(s).state?.theme:null;if(t!=='dark'&&t!=='light'){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}document.documentElement.classList.remove('light','dark');document.documentElement.classList.add(t);}catch(e){document.documentElement.classList.add('dark');}})();`,
           }}
         />
       </head>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,11 +38,18 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         <Providers>
+          {/* Skip link — visually hidden until focused; lets keyboard users bypass nav */}
+          <a href="#main-content" className="skip-link">
+            Skip to main content
+          </a>
           <ScrollRestoration />
           <WebVitalsReporting />
           <Navbar />
           <PageTransitionPlaceholder />
-          {children}
+          {/* id="main-content" is the skip-link target; pages provide the <main> landmark */}
+          <div id="main-content" tabIndex={-1} className="outline-none">
+            {children}
+          </div>
           <TradeStatusBanner />
           <DevPerfOverlay />
         </Providers>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { useWallet } from "@/hooks/useWallet";
@@ -14,14 +14,15 @@ import { PageTransition } from "@/components/PageTransition";
 export default function Home() {
   const { publicKey, connected, connect, disconnect } = useWallet();
   const [tradeOpen, setTradeOpen] = useState(false);
+  const prefersReduced = useReducedMotion();
 
   return (
     <PageTransition>
       <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 sm:gap-8 sm:p-8 bg-gray-950">
         <motion.div
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
+          initial={prefersReduced ? { opacity: 0 } : { opacity: 0, y: -20 }}
+          animate={prefersReduced ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          transition={prefersReduced ? { duration: 0.01 } : { duration: 0.5 }}
           className="relative text-center"
         >
           <h1 className="text-2xl font-bold tracking-tight text-white sm:text-3xl md:text-4xl">
@@ -33,9 +34,9 @@ export default function Home() {
         </motion.div>
 
         <motion.div
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.2, duration: 0.4 }}
+          initial={prefersReduced ? { opacity: 0 } : { opacity: 0, scale: 0.95 }}
+          animate={prefersReduced ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+          transition={prefersReduced ? { duration: 0.01 } : { delay: 0.2, duration: 0.4 }}
           className="flex flex-col items-center gap-4"
         >
           {connected ? (

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -108,7 +108,8 @@ export function AppShell({ children }: AppShellProps) {
 
   return (
     <PageTransition>
-      <main className="min-h-screen bg-background px-4 py-6 sm:px-6 sm:py-8 lg:px-8 text-foreground">
+      {/* `div` here because <main id="main-content"> lives in the root layout */}
+      <div className="min-h-screen bg-background px-4 py-6 sm:px-6 sm:py-8 lg:px-8 text-foreground">
         <header className="mx-auto mb-6 flex w-full max-w-7xl items-center justify-between sm:mb-8">
           <h1 className="text-xl font-bold tracking-tight text-foreground sm:text-2xl">StellarSwipe</h1>
           <div className="flex items-center gap-3">

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -161,7 +161,7 @@ export function AppShell({ children }: AppShellProps) {
                     </button>
                   </div>
                 </div>
-              </div>
+              </PortfolioErrorBoundary>
 
               <div className="w-full max-w-md">
                 <PositionStopLossControl />
@@ -185,7 +185,7 @@ export function AppShell({ children }: AppShellProps) {
           walletBalance={250}
           portfolioBalance={portfolioBalance}
         />
-      </main>
+      </div>
     </PageTransition>
   );
 }

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { useWallet } from "@/hooks/useWallet";
 import { useTransactionStore } from "@/store/useTransactionStore";
 import { Button } from "@/components/ui/button";
@@ -65,15 +65,17 @@ export function AppShell({ children }: AppShellProps) {
     [assets]
   );
 
+  const prefersReduced = useReducedMotion();
+
   if (!connected) {
     return (
       <PageTransition>
         <OnboardingFlow />
         <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-4 sm:gap-8 sm:p-8 bg-background text-foreground">
           <motion.div
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5 }}
+            initial={prefersReduced ? { opacity: 0 } : { opacity: 0, y: -20 }}
+            animate={prefersReduced ? { opacity: 1 } : { opacity: 1, y: 0 }}
+            transition={prefersReduced ? { duration: 0.01 } : { duration: 0.5 }}
             className="relative text-center"
           >
             <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl md:text-4xl">
@@ -83,9 +85,9 @@ export function AppShell({ children }: AppShellProps) {
           </motion.div>
 
           <motion.div
-            initial={{ opacity: 0, scale: 0.95 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ delay: 0.2, duration: 0.4 }}
+            initial={prefersReduced ? { opacity: 0 } : { opacity: 0, scale: 0.95 }}
+            animate={prefersReduced ? { opacity: 1 } : { opacity: 1, scale: 1 }}
+            transition={prefersReduced ? { duration: 0.01 } : { delay: 0.2, duration: 0.4 }}
             className="flex flex-col items-center gap-4"
           >
             <Button

--- a/components/CTABanner.tsx
+++ b/components/CTABanner.tsx
@@ -4,13 +4,15 @@ import { Wallet } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useWallet } from "@/hooks/useWallet";
 import { useState } from "react";
-import { motion } from "framer-motion";
-import { fadeInVariants, useScrollViewport } from "@/hooks/useScrollAnimation";
+import { motion, useReducedMotion } from "framer-motion";
+import { fadeInVariants, fadeInVariantsReduced, useScrollViewport } from "@/hooks/useScrollAnimation";
 
 export function CTABanner() {
   const { connected, connect } = useWallet();
   const [loading, setLoading] = useState(false);
   const scrollProps = useScrollViewport();
+  const prefersReduced = useReducedMotion();
+  const variants = prefersReduced ? fadeInVariantsReduced : fadeInVariants;
 
   async function handleConnect() {
     setLoading(true);
@@ -25,7 +27,7 @@ export function CTABanner() {
 
   return (
     <motion.section
-      variants={fadeInVariants}
+      variants={variants}
       {...scrollProps}
       className="w-full rounded-2xl bg-gradient-to-br from-sky-600 via-blue-700 to-indigo-800 p-8 sm:p-12 text-center shadow-xl"
       aria-labelledby="cta-heading"

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { Wallet, Users, Zap } from "lucide-react";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { fadeUpVariants, fadeUpVariantsReduced, useScrollViewport } from "@/hooks/useScrollAnimation";
-import { useReducedMotion } from "framer-motion";
 
 const steps = [
   {

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -2,7 +2,8 @@
 
 import { Wallet, Users, Zap } from "lucide-react";
 import { motion } from "framer-motion";
-import { fadeUpVariants, useScrollViewport } from "@/hooks/useScrollAnimation";
+import { fadeUpVariants, fadeUpVariantsReduced, useScrollViewport } from "@/hooks/useScrollAnimation";
+import { useReducedMotion } from "framer-motion";
 
 const steps = [
   {
@@ -24,6 +25,8 @@ const steps = [
 
 export function HowItWorks() {
   const scrollProps = useScrollViewport();
+  const prefersReduced = useReducedMotion();
+  const variants = prefersReduced ? fadeUpVariantsReduced : fadeUpVariants;
   return (
     <section className="w-full py-16 px-6" aria-labelledby="how-heading">
       <div className="mx-auto max-w-4xl text-center mb-12">
@@ -47,7 +50,7 @@ export function HowItWorks() {
               <motion.div
                 key={step.title}
                 custom={i}
-                variants={fadeUpVariants}
+                variants={variants}
                 {...scrollProps}
                 className="flex flex-col items-center text-center gap-4"
               >

--- a/components/OnboardingFlow.tsx
+++ b/components/OnboardingFlow.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useOnboardingStore } from "@/store/useOnboardingStore";
 import { Button } from "@/components/ui/button";
 import { ChevronRight, Wallet, LayoutList, ArrowLeftRight, X } from "lucide-react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 interface OnboardingStep {
   icon: React.ElementType;
@@ -36,6 +37,12 @@ export function OnboardingFlow() {
   const { dismissed, setCompleted, setDismissed } = useOnboardingStore();
   const [step, setStep] = useState(0);
 
+  // Trap focus inside the onboarding dialog and restore it on dismiss
+  const focusTrapRef = useFocusTrap({
+    isActive: !dismissed,
+    initialFocus: 'button[aria-label^="Next"]',
+  });
+
   if (dismissed) return null;
 
   const current = STEPS[step];
@@ -57,7 +64,7 @@ export function OnboardingFlow() {
       aria-label="Welcome to StellarSwipe"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
     >
-      <div className="relative w-full max-w-sm rounded-3xl border border-white/10 bg-slate-950 p-6 shadow-2xl shadow-black/50">
+      <div ref={focusTrapRef} className="relative w-full max-w-sm rounded-3xl border border-white/10 bg-slate-950 p-6 shadow-2xl shadow-black/50">
         {/* Skip button */}
         <button
           type="button"

--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 import { ReactNode } from "react";
-import { useReducedMotion } from "framer-motion";
 
 interface PageTransitionProps {
   children: ReactNode;

--- a/components/PageTransition.tsx
+++ b/components/PageTransition.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { ReactNode } from "react";
+import { useReducedMotion } from "framer-motion";
 
 interface PageTransitionProps {
   children: ReactNode;
@@ -13,14 +14,27 @@ const variants = {
   exit: { opacity: 0, y: -12 },
 };
 
+/** Instant variants used when the user prefers reduced motion */
+const reducedVariants = {
+  hidden: { opacity: 0 },
+  enter: { opacity: 1 },
+  exit: { opacity: 0 },
+};
+
 export function PageTransition({ children }: PageTransitionProps) {
+  const prefersReduced = useReducedMotion();
+
   return (
     <motion.div
       initial="hidden"
       animate="enter"
       exit="exit"
-      variants={variants}
-      transition={{ duration: 0.25, ease: "easeInOut" }}
+      variants={prefersReduced ? reducedVariants : variants}
+      transition={
+        prefersReduced
+          ? { duration: 0.01 } // effectively instant
+          : { duration: 0.25, ease: "easeInOut" }
+      }
     >
       {children}
     </motion.div>

--- a/components/PageTransitionPlaceholder.tsx
+++ b/components/PageTransitionPlaceholder.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useRef } from "react";
 import { usePathname } from "next/navigation";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { usePageTransitionStore } from "@/store/usePageTransitionStore";
 import { PageTransitionSkeleton } from "./PageTransitionSkeleton";
 
@@ -47,6 +47,7 @@ export function PageTransitionPlaceholder({
   const pathname = usePathname();
   const { isTransitioning, startTransition, completeTransition } =
     usePageTransitionStore();
+  const prefersReduced = useReducedMotion();
 
   const prevPathname = useRef(pathname);
   const [visiblePlaceholder, setVisiblePlaceholder] = useState(false);
@@ -107,13 +108,14 @@ export function PageTransitionPlaceholder({
       {(isTransitioning || visiblePlaceholder) && (
         <motion.div
           key="page-transition-placeholder"
-          initial={{ opacity: 0, y: 12 }}
+          initial={{ opacity: 0, y: prefersReduced ? 0 : 12 }}
           animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -12 }}
-          transition={{
-            duration: 0.25,
-            ease: "easeInOut",
-          }}
+          exit={{ opacity: 0, y: prefersReduced ? 0 : -12 }}
+          transition={
+            prefersReduced
+              ? { duration: 0.01 }
+              : { duration: 0.25, ease: "easeInOut" }
+          }
           className="fixed inset-0 top-14 z-loading bg-background pointer-events-none overflow-y-auto"
           aria-hidden="true"
           role="status"

--- a/components/SignalFilterBottomSheet.tsx
+++ b/components/SignalFilterBottomSheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { X, SlidersHorizontal } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -8,6 +8,7 @@ import {
   FilterDirection,
   useSignalFilterStore,
 } from "@/store/useSignalFilterStore";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 const DIRECTIONS: { label: string; value: FilterDirection }[] = [
   { label: "All", value: "ALL" },
@@ -48,54 +49,11 @@ export function SignalFilterBottomSheet({
     reset,
   } = useSignalFilterStore();
 
-  const sheetRef = useRef<HTMLDivElement>(null);
-  const closeButtonRef = useRef<HTMLButtonElement>(null);
-
-  // Focus the close button when the sheet opens
-  useEffect(() => {
-    if (open) {
-      // Small delay so the animation has started
-      const id = setTimeout(() => closeButtonRef.current?.focus(), 80);
-      return () => clearTimeout(id);
-    }
-  }, [open]);
-
-  // Trap focus inside the sheet while open
-  useEffect(() => {
-    if (!open) return;
-
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-      if (e.key !== "Tab") return;
-
-      const sheet = sheetRef.current;
-      if (!sheet) return;
-
-      const focusable = sheet.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last?.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first?.focus();
-        }
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open, onClose]);
+  const sheetRef = useFocusTrap({
+    isActive: open,
+    // Focus the close button when the sheet opens
+    initialFocus: 'button[aria-label="Close filters"]',
+  });
 
   // Prevent body scroll while sheet is open
   useEffect(() => {
@@ -108,7 +66,6 @@ export function SignalFilterBottomSheet({
       document.body.style.overflow = "";
     };
   }, [open]);
-
   const isActive = direction !== "ALL" || asset !== "" || provider !== "" || bookmarkedOnly;
 
   return (
@@ -176,7 +133,6 @@ export function SignalFilterBottomSheet({
                   </button>
                 )}
                 <button
-                  ref={closeButtonRef}
                   onClick={onClose}
                   aria-label="Close filters"
                   className="rounded-full p-1.5 text-slate-400 hover:bg-white/10 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"

--- a/hooks/usePrefersReducedMotion.ts
+++ b/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * usePrefersReducedMotion
+ * ───────────────────────
+ * Detects the user's `prefers-reduced-motion` system/browser setting and
+ * returns `true` when the user has requested reduced motion.
+ *
+ * For Framer Motion components, prefer the built-in `useReducedMotion()`
+ * hook from framer-motion instead of this hook.
+ *
+ * Use this hook for:
+ * - CSS-in-JS animation decisions
+ * - Canvas / requestAnimationFrame loops
+ * - Non-framer-motion animation libraries
+ * - Deciding whether to render decorative animated elements at all
+ *
+ * Behaviour:
+ * - Returns `false` on the server (SSR safe) and updates after mount.
+ * - Reacts to live changes (e.g. user toggles OS setting while tab is open).
+ * - Falls back to `false` (allow motion) in environments that don't support
+ *   matchMedia (e.g. old browsers, test environments without mocks).
+ *
+ * @example
+ * const reduced = usePrefersReducedMotion();
+ * const style = { transition: reduced ? 'none' : 'transform 0.3s ease' };
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    const mq =
+      typeof window !== "undefined"
+        ? window.matchMedia("(prefers-reduced-motion: reduce)")
+        : null;
+
+    if (!mq) return;
+
+    // Set the initial value
+    setPrefersReduced(mq.matches);
+
+    // React to live changes
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  return prefersReduced;
+}

--- a/hooks/useScrollAnimation.ts
+++ b/hooks/useScrollAnimation.ts
@@ -19,6 +19,30 @@ export const fadeInVariants: Variants = {
   }),
 };
 
+/**
+ * Reduced-motion equivalents — no translation, minimal fade duration.
+ * Used automatically by useScrollViewport() when the user prefers reduced motion.
+ */
+export const fadeUpVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.01 } },
+};
+
+export const fadeInVariantsReduced: Variants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.01 } },
+};
+
+/**
+ * Returns Framer Motion scroll-viewport props that respect prefers-reduced-motion.
+ *
+ * When the user prefers reduced motion:
+ * - initial is set to "visible" so elements are always shown without animation
+ * - No whileInView / viewport observation is needed
+ *
+ * When motion is allowed:
+ * - Elements start as "hidden" and animate to "visible" once they enter the viewport
+ */
 export function useScrollViewport() {
   const reduced = useReducedMotion();
   return {

--- a/store/useThemeStore.ts
+++ b/store/useThemeStore.ts
@@ -14,9 +14,23 @@ interface ThemeState {
 export const useThemeStore = create<ThemeState>()(
   persist(
     (set, get) => ({
+      // Default to "dark"; the blocking inline script in layout.tsx overrides
+      // this at paint time based on the persisted value or system preference.
       theme: "dark",
-      setTheme: (theme) => set({ theme }),
-      toggle: () => set({ theme: get().theme === "dark" ? "light" : "dark" }),
+      setTheme: (theme) => {
+        set({ theme });
+        // Keep the <html> class in sync immediately for instant visual feedback
+        const root = document.documentElement;
+        root.classList.remove("light", "dark");
+        root.classList.add(theme);
+      },
+      toggle: () => {
+        const next = get().theme === "dark" ? "light" : "dark";
+        set({ theme: next });
+        const root = document.documentElement;
+        root.classList.remove("light", "dark");
+        root.classList.add(next);
+      },
     }),
     {
       name: "stellar-theme",


### PR DESCRIPTION
Summary

Closes #232 
Closes #233 
Closes #234 
Closes #235 

- Skip link + landmarks — Added a visually-hidden "Skip to main content" link in the root layout that appears on focus, targeting #main-content.

- Focus trap audit — SignalFilterBottomSheet had its own inline focus trap logic; replaced with the shared useFocusTrap hook. OnboardingFlow had a dialog with no trap at all; added it. All other modals were already covered.

- Theme flash (FOUC) — Hardened the blocking inline script: strictly validates the stored theme value, falls back to prefers-color-scheme, catches errors. Also made useThemeStore's toggle/setTheme sync the <html> class immediately.

- Reduced motion — Added usePrefersReducedMotion hook. PageTransition, PageTransitionPlaceholder, HowItWorks, CTABanner, AppShell, and the home page all skip translate/scale animations when the user prefers reduced motion. CSS keyframe animations (dialog slide/zoom, skeleton pulse) are also suppressed via @media (prefers-reduced-motion: reduce).