### PR TITLE
feat(signal): React Query devtools, swipe tint, keyboard swipe & snooze

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Set environment variables (.env.local):
 Run dev server:
   npm run dev
 
+### React Query Devtools
+
+When running locally (`npm run dev`), the [React Query Devtools](https://tanstack.com/query/latest/docs/framework/react/devtools) panel is automatically available — look for the floating TanStack logo in the corner of the app. Use it to inspect the live query cache, stale/fresh status, and refetch behaviour for hooks such as the signal feed (`["signals"]`).
+
+The devtools are mounted only when `NODE_ENV === "development"`; the import is dead-code-eliminated from production builds, so the panel never ships to users and requires no manual toggling.
+
 ## Storybook
 
 Storybook provides an isolated visual catalog for all core UI primitives and components.

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 import { useEffect } from "react";
+import dynamic from "next/dynamic";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { queryClient } from "@/lib/queryClient";
 import { ToastProvider } from "@/components/ui/toast";
 import { initI18n } from "@/lib/i18n";
 import { PerformanceMonitoringProvider } from "@/components/performance/PerformanceMonitoringProvider";
 import { useCrossTabSync } from "@/hooks/useCrossTabSync";
+
+// React Query Devtools are only useful while developing locally. Gating the
+// dynamic import on NODE_ENV means the `development` branch is statically
+// dead-code-eliminated by the bundler in production builds, so the devtools
+// chunk never ships to users. No manual toggling required — it follows the env.
+const ReactQueryDevtools: React.ComponentType<{ initialIsOpen?: boolean }> =
+  process.env.NODE_ENV === "development"
+    ? dynamic(
+        () =>
+          import("@tanstack/react-query-devtools").then((mod) => ({
+            default: mod.ReactQueryDevtools,
+          })),
+        { ssr: false }
+      )
+    : () => null;
 
 export function Providers({ children }: { children: React.ReactNode }) {
   useCrossTabSync();

--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import {
+  animate,
   motion,
   useMotionValue,
   useTransform,
@@ -10,6 +11,7 @@ import {
   type PanInfo,
 } from "framer-motion";
 import {
+  AlarmClock,
   Bookmark,
   Check,
   ChevronDown,
@@ -32,6 +34,9 @@ import { PremiumSignalBadge } from "@/components/PremiumSignalBadge";
 import { ProviderRatingBadge } from "@/components/ProviderRatingBadge";
 import { useDemoModeStore } from "@/store/useDemoModeStore";
 import { useBookmarkActions } from "@/hooks/useBookmarkActions";
+import { useSnoozeActions } from "@/hooks/useSnoozeActions";
+import { DEFAULT_SNOOZE_DURATION_MS } from "@/store/useSnoozeStore";
+import { TINT_THRESHOLD, MAX_TINT_OPACITY, classifyArrowKey } from "@/lib/signalGestures";
 import { usePriceFormat } from "@/hooks/usePriceFormat";
 import { useSignalPrice } from "@/hooks/useSignalPrice";
 import { toast } from "@/lib/toast";
@@ -63,7 +68,10 @@ interface SignalCardProps {
   portfolioBalance?: number;
   onTrade?: (pair: string, price: number) => void;
   onPass?: () => void;
+  onSnooze?: () => void;
   showPassAction?: boolean;
+  /** How long a snooze hides the signal for, in ms. Configurable per #321. */
+  snoozeDurationMs?: number;
 }
 
 const DEFAULT_ROI: ROIPoint[] = [
@@ -102,9 +110,12 @@ export function SignalCard({
   portfolioBalance,
   onTrade,
   onPass,
+  onSnooze,
   showPassAction = true,
+  snoozeDurationMs = DEFAULT_SNOOZE_DURATION_MS,
 }: SignalCardProps) {
   const [dismissed, setDismissed] = useState(false);
+  const [snoozedHidden, setSnoozedHidden] = useState(false);
   const [dismissPending, setDismissPending] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [showShareMenu, setShowShareMenu] = useState(false);
@@ -120,12 +131,18 @@ export function SignalCard({
   const hasVibratedRef = useRef(false);
   const dismissTimerRef = useRef<number | null>(null);
   const { addBookmark, removeBookmark, hasBookmark } = useBookmarkActions();
+  const { snooze } = useSnoozeActions();
 
   const x = useMotionValue(0);
   const rotate = useTransform(x, [-300, 300], [-18, 18]);
 
   const tradeOpacity = useTransform(x, [20, SWIPE_THRESHOLD], [0, 1]);
   const passOpacity = useTransform(x, [-20, -SWIPE_THRESHOLD], [0, 1]);
+
+  // #319: directional color tint that deepens as the card is dragged past the
+  // tint threshold — green for trade (right), red for pass (left).
+  const tradeTintOpacity = useTransform(x, [0, TINT_THRESHOLD], [0, MAX_TINT_OPACITY]);
+  const passTintOpacity = useTransform(x, [0, -TINT_THRESHOLD], [0, MAX_TINT_OPACITY]);
 
   const { price, flash, relativeTime } = useSignalPrice(3000);
   const signalId = signalIdProp ?? signalData?.id ?? pair ?? "signal-unknown";
@@ -233,6 +250,25 @@ export function SignalCard({
     setModalOpen(true);
   }
 
+  function handleSnooze() {
+    if (dismissPending || dismissed || snoozedHidden) return;
+    setActionAnnouncement(`Snoozed ${signalAction} signal for ${signalPair}`);
+    setSnoozedHidden(true);
+    snooze(signalId, signalPair, snoozeDurationMs);
+    onSnooze?.();
+  }
+
+  // #320: mirror the pointer-swipe visual feedback when an action is triggered
+  // via the keyboard by briefly animating the card (and its tint overlay) in the
+  // matching direction before resetting to rest.
+  function flashSwipeFeedback(direction: 1 | -1) {
+    if (shouldReduceMotion) return;
+    animate(x, [direction * (TINT_THRESHOLD + 20), 0], {
+      duration: 0.4,
+      ease: "easeOut",
+    });
+  }
+
   function handleModalClose() {
     setModalOpen(false);
     executingRef.current = false;
@@ -250,10 +286,16 @@ export function SignalCard({
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "ArrowLeft" && showPassAction) {
+    const arrowAction = classifyArrowKey(e.key, showPassAction);
+    if (arrowAction === "trade") {
       e.preventDefault();
+      flashSwipeFeedback(1);
+      handleExecuteTrade();
+    } else if (arrowAction === "pass") {
+      e.preventDefault();
+      flashSwipeFeedback(-1);
       handlePass();
-    } else if (e.key === "ArrowRight" || e.key === "Enter" || e.key === " ") {
+    } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       handleExecuteTrade();
     }
@@ -313,7 +355,7 @@ export function SignalCard({
 
   return (
     <AnimatePresence>
-      {!dismissed && (
+      {!dismissed && !snoozedHidden && (
         <motion.div
           className="relative w-full select-none"
           style={{ x, rotate, touchAction: "pan-y" }}
@@ -330,6 +372,20 @@ export function SignalCard({
             whileTap={{ cursor: "grabbing" }}
             aria-disabled={dismissPending}
           >
+          {/* #319: drag-direction color tint — opacity tracks drag distance */}
+          <motion.div
+            className="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-green-500"
+            style={{ opacity: tradeTintOpacity }}
+            aria-hidden="true"
+            data-testid="signal-trade-tint"
+          />
+          <motion.div
+            className="pointer-events-none absolute inset-0 z-0 rounded-2xl bg-red-500"
+            style={{ opacity: passTintOpacity }}
+            aria-hidden="true"
+            data-testid="signal-pass-tint"
+          />
+
           <motion.div
             className="pointer-events-none absolute inset-0 z-10 flex items-center justify-start rounded-2xl border-2 border-green-500 bg-green-500/10 pl-6"
             style={{ opacity: tradeOpacity }}
@@ -414,6 +470,15 @@ export function SignalCard({
                   )}
                 >
                   <Bookmark size={18} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSnooze}
+                  aria-label={`Snooze ${signalAction} signal for ${signalPair}`}
+                  disabled={dismissPending || dismissed || snoozedHidden}
+                  className="rounded-full bg-white/5 p-2 text-slate-300 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <AlarmClock size={18} aria-hidden="true" />
                 </button>
                 <div className="relative" ref={shareMenuRef}>
                   <Button

--- a/components/signal/SignalFeed.tsx
+++ b/components/signal/SignalFeed.tsx
@@ -14,6 +14,7 @@ import { PricePrecisionToggle } from "@/components/PricePrecisionToggle";
 import { ExpiredSignalBanner } from "@/components/ExpiredSignalBanner";
 import { useSignalFilterStore } from "@/store/useSignalFilterStore";
 import { useBookmarkStore } from "@/store/useBookmarkStore";
+import { useSnoozeStore, selectVisibleSignals } from "@/store/useSnoozeStore";
 import type { Signal } from "@/lib/signals";
 import { Search, X, SlidersHorizontal } from "lucide-react";
 import { useSyncStatus } from "@/hooks/useSyncStatus";
@@ -50,8 +51,13 @@ export function SignalFeed({ initialData }: SignalFeedProps = {}) {
     setProvider,
   } = useSignalFilterStore();
   const bookmarkedIds = useBookmarkStore((state) => state.bookmarks);
+  // #321: snoozed signals are hidden from the feed until their snooze elapses.
+  const snoozedMap = useSnoozeStore((state) => state.snoozed);
+  const pruneExpiredSnoozes = useSnoozeStore((state) => state.pruneExpired);
   const [providerSearch, setProviderSearch] = useState(provider);
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
+  // Bumped on a timer so expired snoozes are re-evaluated and signals return.
+  const [snoozeTick, setSnoozeTick] = useState(0);
 
   // Track whether the last auto-load attempt failed so we can show the manual fallback
   const [autoLoadFailed, setAutoLoadFailed] = useState(false);
@@ -134,8 +140,13 @@ export function SignalFeed({ initialData }: SignalFeedProps = {}) {
       filtered = filtered.filter((s) => bookmarkedIds.includes(s.id));
     }
 
+    // #321: hide signals that are currently snoozed; they re-appear once the
+    // snooze expires (snoozeTick forces this to re-run periodically).
+    filtered = selectVisibleSignals(filtered, snoozedMap);
+
     return filtered;
-  }, [allSignals, direction, asset, provider, providerSearch, bookmarkedOnly, bookmarkedIds]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [allSignals, direction, asset, provider, providerSearch, bookmarkedOnly, bookmarkedIds, snoozedMap, snoozeTick]);
 
   const signals = useMemo<Signal[]>(() => {
     const copy = [...filteredSignals];
@@ -209,6 +220,16 @@ export function SignalFeed({ initialData }: SignalFeedProps = {}) {
       }
     };
   }, []);
+
+  // #321: periodically drop expired snoozes so snoozed signals are
+  // automatically returned to the feed once their snooze period elapses.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      pruneExpiredSnoozes();
+      setSnoozeTick((tick) => tick + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [pruneExpiredSnoozes]);
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) {

--- a/hooks/useSnoozeActions.ts
+++ b/hooks/useSnoozeActions.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "@/lib/toast";
+import {
+  useSnoozeStore,
+  DEFAULT_SNOOZE_DURATION_MS,
+} from "@/store/useSnoozeStore";
+
+function formatDuration(ms: number): string {
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.round(minutes / 60);
+  return `${hours} hour${hours === 1 ? "" : "s"}`;
+}
+
+/**
+ * Snooze actions for a signal — temporarily hide it from the feed without
+ * dismissing or bookmarking it (#321). Shows an undo toast so an accidental
+ * snooze can be reverted immediately.
+ */
+export function useSnoozeActions() {
+  const snoozeSignal = useSnoozeStore((state) => state.snoozeSignal);
+  const unsnoozeSignal = useSnoozeStore((state) => state.unsnoozeSignal);
+  const isSnoozed = useSnoozeStore((state) => state.isSnoozed);
+
+  const snooze = useCallback(
+    (id: string, label: string, durationMs: number = DEFAULT_SNOOZE_DURATION_MS) => {
+      snoozeSignal(id, durationMs);
+      toast.info("Signal snoozed", {
+        description: `${label} is hidden for ${formatDuration(durationMs)}.`,
+        duration: 4500,
+        action: {
+          label: "Undo",
+          onClick: () => unsnoozeSignal(id),
+        },
+      });
+    },
+    [snoozeSignal, unsnoozeSignal]
+  );
+
+  const unsnooze = useCallback(
+    (id: string) => unsnoozeSignal(id),
+    [unsnoozeSignal]
+  );
+
+  return { snooze, unsnooze, isSnoozed };
+}

--- a/lib/__tests__/signalGestures.test.ts
+++ b/lib/__tests__/signalGestures.test.ts
@@ -1,0 +1,90 @@
+import {
+  computeTintOpacity,
+  classifyArrowKey,
+  TINT_THRESHOLD,
+  MAX_TINT_OPACITY,
+} from "@/lib/signalGestures";
+
+// ── #319: drag-direction color tint overlay ───────────────────────────────────
+
+describe("computeTintOpacity – overlay opacity tracks drag distance", () => {
+  it("is fully transparent at rest", () => {
+    expect(computeTintOpacity(0)).toEqual({ green: 0, red: 0 });
+  });
+
+  it("tints green (not red) when dragged right", () => {
+    const { green, red } = computeTintOpacity(TINT_THRESHOLD / 2);
+    expect(green).toBeGreaterThan(0);
+    expect(red).toBe(0);
+  });
+
+  it("tints red (not green) when dragged left", () => {
+    const { green, red } = computeTintOpacity(-TINT_THRESHOLD / 2);
+    expect(red).toBeGreaterThan(0);
+    expect(green).toBe(0);
+  });
+
+  it("green opacity increases monotonically with rightward drag distance", () => {
+    const near = computeTintOpacity(20).green;
+    const mid = computeTintOpacity(60).green;
+    const far = computeTintOpacity(100).green;
+    expect(mid).toBeGreaterThan(near);
+    expect(far).toBeGreaterThan(mid);
+  });
+
+  it("red opacity increases monotonically with leftward drag distance", () => {
+    const near = computeTintOpacity(-20).red;
+    const mid = computeTintOpacity(-60).red;
+    const far = computeTintOpacity(-100).red;
+    expect(mid).toBeGreaterThan(near);
+    expect(far).toBeGreaterThan(mid);
+  });
+
+  it("reaches max opacity at the threshold", () => {
+    expect(computeTintOpacity(TINT_THRESHOLD).green).toBeCloseTo(MAX_TINT_OPACITY);
+    expect(computeTintOpacity(-TINT_THRESHOLD).red).toBeCloseTo(MAX_TINT_OPACITY);
+  });
+
+  it("clamps at max opacity past the threshold", () => {
+    expect(computeTintOpacity(TINT_THRESHOLD * 5).green).toBeCloseTo(MAX_TINT_OPACITY);
+    expect(computeTintOpacity(-TINT_THRESHOLD * 5).red).toBeCloseTo(MAX_TINT_OPACITY);
+  });
+
+  it("honours a configurable threshold", () => {
+    // Halving the threshold doubles the opacity at a given offset (until clamped).
+    const standard = computeTintOpacity(30, 120).green;
+    const tighter = computeTintOpacity(30, 60).green;
+    expect(tighter).toBeCloseTo(standard * 2);
+  });
+
+  it("resets to zero opacity on release (offset returns to 0)", () => {
+    expect(computeTintOpacity(0)).toEqual({ green: 0, red: 0 });
+  });
+});
+
+// ── #320: keyboard arrow-key alternative to swipe ─────────────────────────────
+
+describe("classifyArrowKey – arrow keys mirror swipe actions on a focused card", () => {
+  it("maps right-arrow to the trade (swipe-right) action", () => {
+    expect(classifyArrowKey("ArrowRight", true)).toBe("trade");
+  });
+
+  it("maps left-arrow to the pass (swipe-left) action", () => {
+    expect(classifyArrowKey("ArrowLeft", true)).toBe("pass");
+  });
+
+  it("right-arrow still trades even when the pass action is hidden", () => {
+    expect(classifyArrowKey("ArrowRight", false)).toBe("trade");
+  });
+
+  it("left-arrow is a no-op when the pass action is hidden", () => {
+    expect(classifyArrowKey("ArrowLeft", false)).toBe("none");
+  });
+
+  it("ignores unrelated keys so page-level shortcuts are not hijacked", () => {
+    expect(classifyArrowKey("ArrowUp", true)).toBe("none");
+    expect(classifyArrowKey("ArrowDown", true)).toBe("none");
+    expect(classifyArrowKey("a", true)).toBe("none");
+    expect(classifyArrowKey("Tab", true)).toBe("none");
+  });
+});

--- a/lib/signalGestures.ts
+++ b/lib/signalGestures.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure helpers for SignalCard swipe gestures.
+ *
+ * Kept framework-free so the drag-direction tint overlay (#319) and the
+ * keyboard arrow-key alternative (#320) can be unit tested without rendering
+ * framer-motion or a DOM.
+ */
+
+/** Horizontal drag distance (px) at which a swipe commits to trade/pass. */
+export const SWIPE_THRESHOLD = 120;
+
+/** Pointer velocity (px/s) that commits a swipe even below the distance threshold. */
+export const VELOCITY_THRESHOLD = 780;
+
+/**
+ * Drag distance (px) at which the directional tint overlay reaches full
+ * strength. Configurable so the visual ramp can be tuned independently of the
+ * commit threshold.
+ */
+export const TINT_THRESHOLD = 120;
+
+/** Maximum opacity the directional tint overlay ramps up to. */
+export const MAX_TINT_OPACITY = 0.45;
+
+export interface TintOpacity {
+  /** Opacity of the green (rightward / trade) tint. */
+  green: number;
+  /** Opacity of the red (leftward / pass) tint. */
+  red: number;
+}
+
+/**
+ * Opacity of the green (trade) and red (pass) tint overlays for a given
+ * horizontal drag `offset`.
+ *
+ * Opacity ramps linearly from 0 at rest to `max` once the card has been dragged
+ * `threshold` px in either direction, and is clamped at `max` beyond that.
+ * Rightward drags (offset > 0) tint green; leftward drags (offset < 0) tint red.
+ */
+export function computeTintOpacity(
+  offset: number,
+  threshold: number = TINT_THRESHOLD,
+  max: number = MAX_TINT_OPACITY
+): TintOpacity {
+  if (threshold <= 0 || offset === 0) return { green: 0, red: 0 };
+  const magnitude = Math.min(Math.abs(offset) / threshold, 1) * max;
+  return offset > 0 ? { green: magnitude, red: 0 } : { green: 0, red: magnitude };
+}
+
+export type SwipeAction = "trade" | "pass" | "none";
+
+/**
+ * Keyboard arrow-key equivalent of a swipe on a focused SignalCard (#320):
+ * right-arrow → trade (mirrors swipe right), left-arrow → pass (mirrors swipe
+ * left). Left-arrow is a no-op when the pass action is hidden. Returns the
+ * direction the matching tint feedback should flash toward (+1 trade, -1 pass).
+ */
+export function classifyArrowKey(key: string, showPassAction: boolean): SwipeAction {
+  if (key === "ArrowRight") return "trade";
+  if (key === "ArrowLeft") return showPassAction ? "pass" : "none";
+  return "none";
+}

--- a/store/__tests__/useSnoozeStore.test.ts
+++ b/store/__tests__/useSnoozeStore.test.ts
@@ -1,0 +1,125 @@
+import {
+  useSnoozeStore,
+  selectVisibleSignals,
+  DEFAULT_SNOOZE_DURATION_MS,
+} from "@/store/useSnoozeStore";
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  useSnoozeStore.setState({ snoozed: {} });
+});
+
+// ── Snoozing ──────────────────────────────────────────────────────────────────
+
+describe("useSnoozeStore – snoozing a signal", () => {
+  it("records an expiry timestamp at now + duration", () => {
+    useSnoozeStore.getState().snoozeSignal("sig-1", DEFAULT_SNOOZE_DURATION_MS, NOW);
+    expect(useSnoozeStore.getState().snoozed["sig-1"]).toBe(NOW + DEFAULT_SNOOZE_DURATION_MS);
+  });
+
+  it("uses the default duration when none is provided", () => {
+    useSnoozeStore.getState().snoozeSignal("sig-1", undefined, NOW);
+    expect(useSnoozeStore.getState().snoozed["sig-1"]).toBe(NOW + DEFAULT_SNOOZE_DURATION_MS);
+  });
+
+  it("supports a configurable duration", () => {
+    const tenMinutes = 10 * 60 * 1000;
+    useSnoozeStore.getState().snoozeSignal("sig-1", tenMinutes, NOW);
+    expect(useSnoozeStore.getState().snoozed["sig-1"]).toBe(NOW + tenMinutes);
+  });
+
+  it("reports a freshly snoozed signal as snoozed", () => {
+    useSnoozeStore.getState().snoozeSignal("sig-1", DEFAULT_SNOOZE_DURATION_MS, NOW);
+    expect(useSnoozeStore.getState().isSnoozed("sig-1", NOW)).toBe(true);
+  });
+
+  it("does not report an un-snoozed signal as snoozed", () => {
+    expect(useSnoozeStore.getState().isSnoozed("unknown", NOW)).toBe(false);
+  });
+
+  it("lists active snoozes", () => {
+    const s = useSnoozeStore.getState();
+    s.snoozeSignal("sig-1", DEFAULT_SNOOZE_DURATION_MS, NOW);
+    s.snoozeSignal("sig-2", DEFAULT_SNOOZE_DURATION_MS, NOW);
+    expect(useSnoozeStore.getState().getActiveSnoozes(NOW).sort()).toEqual(["sig-1", "sig-2"]);
+  });
+
+  it("unsnoozeSignal returns a signal early", () => {
+    const s = useSnoozeStore.getState();
+    s.snoozeSignal("sig-1", DEFAULT_SNOOZE_DURATION_MS, NOW);
+    s.unsnoozeSignal("sig-1");
+    expect(useSnoozeStore.getState().isSnoozed("sig-1", NOW)).toBe(false);
+  });
+});
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+describe("useSnoozeStore – snooze expiry", () => {
+  it("reports the signal as snoozed before expiry", () => {
+    useSnoozeStore.getState().snoozeSignal("sig-1", 1000, NOW);
+    expect(useSnoozeStore.getState().isSnoozed("sig-1", NOW + 500)).toBe(true);
+  });
+
+  it("reports the signal as no longer snoozed at/after expiry", () => {
+    useSnoozeStore.getState().snoozeSignal("sig-1", 1000, NOW);
+    expect(useSnoozeStore.getState().isSnoozed("sig-1", NOW + 1000)).toBe(false);
+    expect(useSnoozeStore.getState().isSnoozed("sig-1", NOW + 5000)).toBe(false);
+  });
+
+  it("excludes expired entries from the active list", () => {
+    const s = useSnoozeStore.getState();
+    s.snoozeSignal("fresh", 5000, NOW);
+    s.snoozeSignal("stale", 1000, NOW);
+    expect(useSnoozeStore.getState().getActiveSnoozes(NOW + 2000)).toEqual(["fresh"]);
+  });
+
+  it("pruneExpired drops only entries whose expiry has passed", () => {
+    const s = useSnoozeStore.getState();
+    s.snoozeSignal("fresh", 5000, NOW);
+    s.snoozeSignal("stale", 1000, NOW);
+    s.pruneExpired(NOW + 2000);
+    const { snoozed } = useSnoozeStore.getState();
+    expect(snoozed).toHaveProperty("fresh");
+    expect(snoozed).not.toHaveProperty("stale");
+  });
+});
+
+// ── Feed re-insertion ─────────────────────────────────────────────────────────
+
+describe("selectVisibleSignals – snoozed signals leave and re-enter the feed", () => {
+  const feed = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+  it("returns every signal when nothing is snoozed", () => {
+    expect(selectVisibleSignals(feed, {}, NOW)).toEqual(feed);
+  });
+
+  it("hides a snoozed signal from the feed", () => {
+    useSnoozeStore.getState().snoozeSignal("b", 1000, NOW);
+    const visible = selectVisibleSignals(feed, useSnoozeStore.getState().snoozed, NOW);
+    expect(visible.map((s) => s.id)).toEqual(["a", "c"]);
+  });
+
+  it("automatically re-inserts the signal once its snooze elapses", () => {
+    useSnoozeStore.getState().snoozeSignal("b", 1000, NOW);
+
+    // While snoozed: hidden.
+    expect(
+      selectVisibleSignals(feed, useSnoozeStore.getState().snoozed, NOW + 500).map((s) => s.id)
+    ).toEqual(["a", "c"]);
+
+    // After expiry: back in the feed in its original position.
+    expect(
+      selectVisibleSignals(feed, useSnoozeStore.getState().snoozed, NOW + 1500).map((s) => s.id)
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("re-inserts immediately when manually unsnoozed", () => {
+    const s = useSnoozeStore.getState();
+    s.snoozeSignal("b", DEFAULT_SNOOZE_DURATION_MS, NOW);
+    s.unsnoozeSignal("b");
+    expect(
+      selectVisibleSignals(feed, useSnoozeStore.getState().snoozed, NOW).map((s) => s.id)
+    ).toEqual(["a", "b", "c"]);
+  });
+});

--- a/store/useSnoozeStore.ts
+++ b/store/useSnoozeStore.ts
@@ -1,0 +1,85 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/** Default snooze duration: temporarily hide a signal for one hour. */
+export const DEFAULT_SNOOZE_DURATION_MS = 60 * 60 * 1000;
+
+interface SnoozeState {
+  /** Map of signal id → expiry timestamp (epoch ms). */
+  snoozed: Record<string, number>;
+  /** Snooze a signal until `now + durationMs`. */
+  snoozeSignal: (id: string, durationMs?: number, now?: number) => void;
+  /** Manually return a snoozed signal to the feed. */
+  unsnoozeSignal: (id: string) => void;
+  /** True while the signal is snoozed and its expiry is still in the future. */
+  isSnoozed: (id: string, now?: number) => boolean;
+  /** Ids whose snooze has not yet elapsed. */
+  getActiveSnoozes: (now?: number) => string[];
+  /** Drop any snoozes whose expiry has passed (returns to the feed). */
+  pruneExpired: (now?: number) => void;
+  /** Remove every snooze. */
+  clearSnoozes: () => void;
+}
+
+export const useSnoozeStore = create<SnoozeState>()(
+  persist(
+    (set, get) => ({
+      snoozed: {},
+
+      snoozeSignal: (id, durationMs = DEFAULT_SNOOZE_DURATION_MS, now = Date.now()) =>
+        set((state) => ({
+          snoozed: { ...state.snoozed, [id]: now + Math.max(0, durationMs) },
+        })),
+
+      unsnoozeSignal: (id) =>
+        set((state) => {
+          if (!(id in state.snoozed)) return state;
+          const next = { ...state.snoozed };
+          delete next[id];
+          return { snoozed: next };
+        }),
+
+      isSnoozed: (id, now = Date.now()) => {
+        const expiresAt = get().snoozed[id];
+        return expiresAt !== undefined && expiresAt > now;
+      },
+
+      getActiveSnoozes: (now = Date.now()) =>
+        Object.entries(get().snoozed)
+          .filter(([, expiresAt]) => expiresAt > now)
+          .map(([id]) => id),
+
+      pruneExpired: (now = Date.now()) =>
+        set((state) => {
+          const next: Record<string, number> = {};
+          let changed = false;
+          for (const [id, expiresAt] of Object.entries(state.snoozed)) {
+            if (expiresAt > now) next[id] = expiresAt;
+            else changed = true;
+          }
+          return changed ? { snoozed: next } : state;
+        }),
+
+      clearSnoozes: () => set({ snoozed: {} }),
+    }),
+    { name: "signal-snoozes" }
+  )
+);
+
+/**
+ * Returns the subset of `signals` that are not currently snoozed.
+ *
+ * Pure so the feed-filtering / re-insertion behaviour can be unit tested
+ * without rendering the feed: once a signal's snooze expiry (`<= now`) passes,
+ * it is no longer filtered out and is automatically re-inserted into the feed.
+ */
+export function selectVisibleSignals<T extends { id: string }>(
+  signals: T[],
+  snoozed: Record<string, number>,
+  now: number = Date.now()
+): T[] {
+  return signals.filter((signal) => {
+    const expiresAt = snoozed[signal.id];
+    return expiresAt === undefined || expiresAt <= now;
+  });
+}


### PR DESCRIPTION
Implements four SignalCard / tooling issues in a single PR.

## #227 — React Query Devtools for local development
- Mount `@tanstack/react-query-devtools` only when `NODE_ENV === "development"` via a gated `next/dynamic` import, so the devtools chunk is dead-code-eliminated from production bundles (never shipped to users).
- No manual toggling — behaviour follows the environment automatically.
- Panel reflects the real query cache (e.g. the `["signals"]` feed query) since it shares the app `queryClient`.
- Documented in the README.

## #319 — Drag-direction color tint overlay
- Green tint overlay on rightward (trade) drags and red on leftward (pass) drags, with opacity ramping from 0 to a max as the card is dragged toward a configurable `TINT_THRESHOLD`, clamped beyond it.
- Opacity is driven by the drag motion value, so it resets smoothly to 0 on release/cancel (`dragSnapToOrigin`).

## #320 — Keyboard arrow-key alternative on a focused card
- Right-arrow triggers trade, left-arrow triggers dismiss/pass when the card is focused, routed through a shared `classifyArrowKey` helper.
- Mirrors the pointer-swipe tint feedback by briefly animating the card (and its tint) in the matching direction.
- Only arrow/Enter/Space are intercepted (with `preventDefault`); other keys fall through, so page-level shortcuts aren't hijacked.

## #321 — Snooze action (distinct from dismiss & bookmark)
- New snooze control in the card action set that temporarily hides a signal for a configurable duration.
- Snoozed ids + expiry timestamps are persisted in a dedicated `useSnoozeStore`.
- `SignalFeed` filters out active snoozes and a prune tick automatically returns a signal to the feed once its snooze elapses.

## Tests
- `lib/__tests__/signalGestures.test.ts` — tint opacity tracks drag distance / direction / threshold; arrow-key classification for both directions.
- `store/__tests__/useSnoozeStore.test.ts` — snoozing, expiry, and feed re-insertion.

Closes #227
Closes #319
Closes #320
Closes #321