### PR TITLE
feat: command palette, filter presets, candlestick chart, multi-wallet (#327 #328 #329 #330)

### DIFF
--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useRouter } from "next/navigation";
+import { Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useThemeStore } from "@/store/useThemeStore";
+
+interface CommandItem {
+  id: string;
+  label: string;
+  group: "Routes" | "Actions";
+  href?: string;
+  onSelect?: () => void;
+  keywords?: string[];
+}
+
+function fuzzyMatch(query: string, text: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  let qi = 0;
+  for (let i = 0; i < t.length && qi < q.length; i++) {
+    if (t[i] === q[qi]) qi++;
+  }
+  return qi === q.length;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  onConnectWallet?: () => void;
+}
+
+export function CommandPalette({ open, onClose, onConnectWallet }: CommandPaletteProps) {
+  const router = useRouter();
+  const { toggle: toggleTheme } = useThemeStore();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const items: CommandItem[] = [
+    { id: "home", label: "Home", group: "Routes", href: "/" },
+    { id: "signals", label: "Signals", group: "Routes", href: "/signals" },
+    { id: "bookmarks", label: "Bookmarks", group: "Routes", href: "/bookmarks" },
+    { id: "providers", label: "Providers", group: "Routes", href: "/providers" },
+    { id: "tax-report", label: "Tax Report", group: "Routes", href: "/tax-report", keywords: ["tax", "report"] },
+    { id: "compare", label: "Compare", group: "Routes", href: "/compare" },
+    { id: "backtest", label: "Backtest Simulator", group: "Routes", href: "/backtest-sim", keywords: ["backtest", "sim"] },
+    { id: "referral", label: "Referral", group: "Routes", href: "/referral" },
+    { id: "security", label: "Security", group: "Routes", href: "/security" },
+    { id: "analytics", label: "Analytics", group: "Routes", href: "/analytics" },
+    { id: "performance", label: "Performance", group: "Routes", href: "/performance" },
+    {
+      id: "toggle-theme",
+      label: "Toggle Theme",
+      group: "Actions",
+      onSelect: toggleTheme,
+      keywords: ["dark", "light", "theme", "mode"],
+    },
+    {
+      id: "connect-wallet",
+      label: "Connect Wallet",
+      group: "Actions",
+      onSelect: onConnectWallet,
+      keywords: ["wallet", "freighter", "stellar", "connect"],
+    },
+  ];
+
+  const filtered = items.filter(
+    (item) =>
+      fuzzyMatch(query, item.label) ||
+      item.keywords?.some((k) => fuzzyMatch(query, k))
+  );
+
+  useEffect(() => { setActiveIndex(0); }, [query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setActiveIndex(0);
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (item: CommandItem) => {
+      onClose();
+      if (item.href) {
+        router.push(item.href);
+      } else {
+        item.onSelect?.();
+      }
+    },
+    [onClose, router]
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") { onClose(); return; }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const item = filtered[activeIndex];
+        if (item) handleSelect(item);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose, filtered, activeIndex, handleSelect]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] flex items-start justify-center pt-[18vh]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+    >
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative w-full max-w-lg mx-4 rounded-xl border border-border bg-popover shadow-2xl overflow-hidden">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+          <Search size={15} className="shrink-0 text-muted-foreground" aria-hidden="true" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search routes and actions…"
+            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
+            aria-label="Search command palette"
+            aria-autocomplete="list"
+            aria-controls="command-palette-list"
+            aria-activedescendant={filtered[activeIndex] ? `cmd-${filtered[activeIndex].id}` : undefined}
+          />
+          <button
+            onClick={onClose}
+            aria-label="Close command palette"
+            className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <ul
+          id="command-palette-list"
+          role="listbox"
+          className="max-h-72 overflow-y-auto p-1"
+        >
+          {filtered.length === 0 ? (
+            <li className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No results for &ldquo;{query}&rdquo;
+            </li>
+          ) : (
+            filtered.map((item, i) => (
+              <li
+                key={item.id}
+                id={`cmd-${item.id}`}
+                role="option"
+                aria-selected={i === activeIndex}
+                onClick={() => handleSelect(item)}
+                onMouseEnter={() => setActiveIndex(i)}
+                className={cn(
+                  "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
+                  i === activeIndex
+                    ? "bg-accent text-accent-foreground"
+                    : "text-foreground hover:bg-accent/50"
+                )}
+              >
+                <span className="w-4 text-center text-muted-foreground text-xs" aria-hidden="true">
+                  {item.group === "Routes" ? "→" : "⚡"}
+                </span>
+                <span className="flex-1">{item.label}</span>
+                <span className="text-[10px] text-muted-foreground">{item.group}</span>
+              </li>
+            ))
+          )}
+        </ul>
+
+        <div className="border-t border-border px-4 py-2 flex gap-4 text-[11px] text-muted-foreground">
+          <span><kbd className="font-mono">↑↓</kbd> navigate</span>
+          <span><kbd className="font-mono">↵</kbd> select</span>
+          <span><kbd className="font-mono">Esc</kbd> close</span>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Loader2, Zap } from "lucide-react";
 import { useWallet } from "@/hooks/useWallet";
@@ -9,6 +9,7 @@ import { WalletDropdown } from "@/components/WalletDropdown";
 import { WalletSelectionModal } from "@/components/WalletSelectionModal";
 import { LanguageSelector } from "@/components/LanguageSelector";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { CommandPalette } from "@/components/CommandPalette";
 
 const NAV_LINKS = [
   { href: "/", label: "Home" },
@@ -19,8 +20,20 @@ const NAV_LINKS = [
 ];
 
 export function Navbar() {
-  const { connected, isConnecting } = useWallet();
+  const { connected, isConnecting, connect } = useWallet();
   const [walletModalOpen, setWalletModalOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setPaletteOpen((o) => !o);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   return (
     <>
@@ -80,6 +93,15 @@ export function Navbar() {
       <WalletSelectionModal
         open={walletModalOpen}
         onClose={() => setWalletModalOpen(false)}
+      />
+
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        onConnectWallet={() => {
+          if (connected) return;
+          setWalletModalOpen(true);
+        }}
       />
     </>
   );

--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -30,6 +30,9 @@ import { TradeModal } from "@/components/TradeModal";
 import { SignalConflictNotice, type SignalConflictReason } from "@/components/SignalConflictNotice";
 import { cn } from "@/lib/utils";
 import { MiniChart } from "./chart/MiniChart";
+import { CandlestickChart } from "./chart/CandlestickChart";
+import { useChartStyleStore } from "@/store/useChartStyleStore";
+import { BarChart2, LineChart } from "lucide-react";
 import { PremiumSignalBadge } from "@/components/PremiumSignalBadge";
 import { ProviderRatingBadge } from "@/components/ProviderRatingBadge";
 import { useDemoModeStore } from "@/store/useDemoModeStore";
@@ -125,6 +128,7 @@ export function SignalCard({
   const [actionAnnouncement, setActionAnnouncement] = useState("");
   const shouldReduceMotion = useReducedMotion();
   const { isDemoMode } = useDemoModeStore();
+  const { chartStyle, setChartStyle } = useChartStyleStore();
   const fmt = usePriceFormat();
   const executingRef = useRef(false);
   const shareMenuRef = useRef<HTMLDivElement>(null);
@@ -566,7 +570,20 @@ export function SignalCard({
               ) : (
                 <Minus size={16} className="text-foreground-subtle" />
               )}
-              <MiniChart data={roiHistory.map((p) => p.value)} className="flex-1" />
+              {chartStyle === "candlestick" ? (
+                <CandlestickChart data={roiHistory.map((p) => p.value)} className="flex-1" />
+              ) : (
+                <MiniChart data={roiHistory.map((p) => p.value)} className="flex-1" />
+              )}
+              <button
+                type="button"
+                onClick={() => setChartStyle(chartStyle === "line" ? "candlestick" : "line")}
+                aria-label={`Switch to ${chartStyle === "line" ? "candlestick" : "line"} chart`}
+                aria-pressed={chartStyle === "candlestick"}
+                className="rounded p-1 text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              >
+                {chartStyle === "line" ? <BarChart2 size={14} aria-hidden="true" /> : <LineChart size={14} aria-hidden="true" />}
+              </button>
             </div>
 
             {/* ── Issue #102: Expandable detail section with smooth animation ── */}

--- a/components/SignalFeedFilters.tsx
+++ b/components/SignalFeedFilters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRef } from "react";
-import { Bookmark, SlidersHorizontal, X } from "lucide-react";
+import { useRef, useState } from "react";
+import { Bookmark, Save, SlidersHorizontal, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   FilterDirection,
@@ -33,14 +33,20 @@ export function SignalFeedFilters({
     asset,
     provider,
     bookmarkedOnly,
+    presets,
     setDirection,
     setAsset,
     setProvider,
     setBookmarkedOnly,
+    savePreset,
+    applyPreset,
+    deletePreset,
     reset,
   } = useSignalFilterStore();
   const isHydrated = useSignalFilterHydrated();
   const assetInputRef = useRef<HTMLInputElement>(null);
+  const [presetName, setPresetName] = useState("");
+  const [showPresetInput, setShowPresetInput] = useState(false);
 
   // Render a neutral placeholder until persisted filters are loaded.
   // This prevents filter state from flickering from defaults to saved values.
@@ -239,6 +245,88 @@ export function SignalFeedFilters({
             .join(" · ")}
         </p>
       )}
+
+      {/* Presets */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] font-medium text-foreground-muted uppercase tracking-wide">
+            Presets
+          </span>
+          <button
+            type="button"
+            onClick={() => setShowPresetInput((v) => !v)}
+            className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 rounded"
+            aria-label="Save current filters as preset"
+          >
+            <Save size={11} />
+            Save current
+          </button>
+        </div>
+
+        {showPresetInput && (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const name = presetName.trim();
+              if (!name) return;
+              savePreset(name);
+              setPresetName("");
+              setShowPresetInput(false);
+            }}
+            className="flex gap-2"
+          >
+            <input
+              autoFocus
+              type="text"
+              value={presetName}
+              onChange={(e) => setPresetName(e.target.value)}
+              placeholder="Preset name…"
+              maxLength={40}
+              className="flex-1 rounded-full bg-surface border border-border px-3 py-1 text-xs text-foreground placeholder-foreground-subtle focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Preset name"
+            />
+            <button
+              type="submit"
+              disabled={!presetName.trim()}
+              className="rounded-full bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-500 disabled:opacity-40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowPresetInput(false)}
+              className="rounded-full px-3 py-1 text-xs text-foreground-muted hover:text-foreground border border-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              Cancel
+            </button>
+          </form>
+        )}
+
+        {presets.length > 0 && (
+          <ul className="flex flex-wrap gap-2" role="list" aria-label="Saved filter presets">
+            {presets.map((preset) => (
+              <li key={preset.name} className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => applyPreset(preset.name)}
+                  className="rounded-full bg-surface border border-border px-3 py-1 text-xs text-foreground hover:border-blue-500/60 hover:text-blue-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  aria-label={`Apply preset: ${preset.name}`}
+                >
+                  {preset.name}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => deletePreset(preset.name)}
+                  className="rounded-full p-1 text-foreground-muted hover:text-red-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                  aria-label={`Delete preset: ${preset.name}`}
+                >
+                  <Trash2 size={11} />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </section>
   );
 }

--- a/components/WalletDropdown.tsx
+++ b/components/WalletDropdown.tsx
@@ -4,22 +4,34 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import { useWallet } from "@/hooks/useWallet";
 import { usePortfolio } from "@/hooks/usePortfolio";
 import { Button } from "@/components/ui/button";
-import { Check, Copy, LogOut, ChevronDown, RefreshCw } from "lucide-react";
+import { Check, ChevronDown, Copy, LogOut, PlusCircle, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+function truncate(key: string) {
+  return `${key.slice(0, 6)}...${key.slice(-4)}`;
+}
+
 export function WalletDropdown() {
-  const { publicKey, disconnect } = useWallet();
+  const {
+    publicKey,
+    wallets,
+    activePublicKey,
+    switchWallet,
+    connectAnother,
+    disconnect,
+    disconnectAll,
+    isConnecting,
+  } = useWallet();
   const { refetch } = usePortfolio();
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshed, setRefreshed] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const truncated = publicKey
-    ? `${publicKey.slice(0, 6)}...${publicKey.slice(-4)}`
-    : "";
+  const ref = useRef<HTMLDivElement>(null);
+
+  const truncated = publicKey ? truncate(publicKey) : "";
 
   const handleCopy = useCallback(async () => {
     if (!publicKey) return;
@@ -46,64 +58,39 @@ export function WalletDropdown() {
     }
   }, [isRefreshing, refetch]);
 
-  // Close on outside click
   useEffect(() => {
     function onPointerDown(e: PointerEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        handleClose();
-      }
+      if (ref.current && !ref.current.contains(e.target as Node)) handleClose();
     }
     document.addEventListener("pointerdown", onPointerDown);
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, []);
 
-  // Close on Escape + keyboard navigation within menu
   useEffect(() => {
     function onKeyDown(e: globalThis.KeyboardEvent) {
-      if (e.key === "Escape") {
-        handleClose();
-        return;
-      }
-
-      // Arrow-based navigation within the menu
+      if (e.key === "Escape") { handleClose(); return; }
       if (open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
         e.preventDefault();
         const menu = menuRef.current;
         if (!menu) return;
-
-        const items = Array.from(
-          menu.querySelectorAll<HTMLElement>('[role="menuitem"]')
-        );
-        if (items.length === 0) return;
-
-        const currentIndex = items.indexOf(document.activeElement as HTMLElement);
-        let nextIndex: number;
-
-        if (e.key === "ArrowDown") {
-          nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
-        } else {
-          nextIndex =
-            currentIndex < 0
-              ? items.length - 1
-              : (currentIndex - 1 + items.length) % items.length;
-        }
-
-        items[nextIndex]?.focus();
+        const items = Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'));
+        if (!items.length) return;
+        const idx = items.indexOf(document.activeElement as HTMLElement);
+        const next =
+          e.key === "ArrowDown"
+            ? idx < 0 ? 0 : (idx + 1) % items.length
+            : idx < 0 ? items.length - 1 : (idx - 1 + items.length) % items.length;
+        items[next]?.focus();
       }
     }
-
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [open]);
 
-  // Focus first menuitem when dropdown opens
   useEffect(() => {
     if (!open) return;
     const frame = requestAnimationFrame(() => {
-      const menu = menuRef.current;
-      if (!menu) return;
-      const firstItem = menu.querySelector<HTMLElement>('[role="menuitem"]');
-      firstItem?.focus();
+      menuRef.current?.querySelector<HTMLElement>('[role="menuitem"]')?.focus();
     });
     return () => cancelAnimationFrame(frame);
   }, [open]);
@@ -116,30 +103,20 @@ export function WalletDropdown() {
         onClick={() => setOpen((o) => !o)}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label={
-          publicKey
-            ? `Wallet menu for ${truncated}. Click to open wallet actions.`
-            : "Wallet menu"
-        }
+        aria-label={publicKey ? `Wallet menu for ${truncated}` : "Wallet menu"}
         className="font-mono gap-2"
       >
-        {/* Connection status dot */}
-        <span
-          className="relative flex h-2 w-2 shrink-0"
-          aria-hidden="true"
-          title="Wallet connected"
-        >
+        <span className="relative flex h-2 w-2 shrink-0" aria-hidden="true">
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-60" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
         </span>
-
-        {/* Address — hidden on very small screens */}
         <span className="hidden xs:inline">{truncated}</span>
-
-        <ChevronDown
-          aria-hidden="true"
-          className={cn("h-4 w-4 transition-transform", open && "rotate-180")}
-        />
+        {wallets.length > 1 && (
+          <span className="rounded-full bg-blue-500/20 px-1.5 text-[10px] text-blue-400 font-semibold">
+            {wallets.length}
+          </span>
+        )}
+        <ChevronDown aria-hidden="true" className={cn("h-4 w-4 transition-transform", open && "rotate-180")} />
       </Button>
 
       {open && (
@@ -147,23 +124,68 @@ export function WalletDropdown() {
           ref={menuRef}
           role="menu"
           aria-label="Wallet options"
-          className="absolute right-0 mt-2 w-72 rounded-xl border bg-popover shadow-lg p-2 flex flex-col gap-1 z-50"
+          className="absolute right-0 mt-2 w-80 rounded-xl border bg-popover shadow-lg p-2 flex flex-col gap-1 z-50"
         >
-          {/* Connection status header */}
-          <div className="px-3 py-2 flex items-center gap-2">
-            <span className="relative flex h-2 w-2 shrink-0" aria-hidden="true">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-60" />
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
-            </span>
-            <span className="text-xs font-medium text-green-400">Connected</span>
-          </div>
+          {/* Connected wallets list */}
+          {wallets.length > 0 && (
+            <div className="px-3 py-2">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Connected wallets
+              </p>
+              <ul className="flex flex-col gap-1" role="list">
+                {wallets.map((w) => {
+                  const isActive = w.publicKey === activePublicKey;
+                  return (
+                    <li key={w.publicKey}>
+                      <button
+                        role="menuitem"
+                        tabIndex={0}
+                        onClick={() => {
+                          if (!isActive) switchWallet(w.publicKey);
+                        }}
+                        aria-label={
+                          isActive
+                            ? `Active wallet: ${truncate(w.publicKey)}`
+                            : `Switch to wallet: ${truncate(w.publicKey)}`
+                        }
+                        className={cn(
+                          "w-full flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-xs font-mono transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          isActive
+                            ? "bg-blue-500/15 text-blue-300 border border-blue-500/30"
+                            : "hover:bg-accent text-muted-foreground"
+                        )}
+                      >
+                        <span>{truncate(w.publicKey)}</span>
+                        {isActive && <Check className="h-3 w-3 text-blue-400" aria-label="Active" />}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
 
-          {/* Full address */}
+          <hr className="border-border" />
+
+          {/* Add another wallet */}
+          <button
+            role="menuitem"
+            tabIndex={0}
+            onClick={() => { handleClose(); connectAnother(); }}
+            disabled={isConnecting}
+            aria-label="Connect another wallet"
+            className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors disabled:opacity-60"
+          >
+            <PlusCircle className="h-4 w-4 text-blue-400" aria-hidden="true" />
+            Connect another wallet
+          </button>
+
+          <hr className="border-border" />
+
+          {/* Full active address */}
           <p className="px-3 py-2 text-xs font-mono text-muted-foreground break-all select-all">
             {publicKey}
           </p>
-
-          <hr className="border-border" />
 
           {/* Refresh balance */}
           <button
@@ -171,32 +193,16 @@ export function WalletDropdown() {
             tabIndex={0}
             onClick={handleRefresh}
             disabled={isRefreshing}
-            aria-label={
-              isRefreshing
-                ? "Refreshing wallet balance..."
-                : refreshed
-                ? "Balance refreshed"
-                : "Refresh wallet balance"
-            }
+            aria-label={isRefreshing ? "Refreshing wallet balance…" : refreshed ? "Balance refreshed" : "Refresh wallet balance"}
             className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors disabled:cursor-not-allowed disabled:opacity-60"
           >
             {refreshed ? (
               <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
             ) : (
-              <RefreshCw
-                className={cn(
-                  "h-4 w-4",
-                  isRefreshing && "animate-spin text-blue-400"
-                )}
-                aria-hidden="true"
-              />
+              <RefreshCw className={cn("h-4 w-4", isRefreshing && "animate-spin text-blue-400")} aria-hidden="true" />
             )}
             <span aria-live="polite">
-              {isRefreshing
-                ? "Refreshing..."
-                : refreshed
-                ? "Balance updated"
-                : "Refresh balance"}
+              {isRefreshing ? "Refreshing…" : refreshed ? "Balance updated" : "Refresh balance"}
             </span>
           </button>
 
@@ -208,32 +214,39 @@ export function WalletDropdown() {
             aria-label={copied ? "Address copied" : "Copy wallet address"}
             className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
           >
-            {copied ? (
-              <Check aria-hidden="true" className="h-4 w-4 text-green-600" />
-            ) : (
-              <Copy aria-hidden="true" className="h-4 w-4" />
-            )}
+            {copied ? <Check aria-hidden="true" className="h-4 w-4 text-green-600" /> : <Copy aria-hidden="true" className="h-4 w-4" />}
             {copied ? "Copied!" : "Copy address"}
           </button>
 
-          {/* Disconnect */}
+          <hr className="border-border" />
+
+          {/* Disconnect active */}
           <button
             role="menuitem"
             tabIndex={0}
-            onClick={() => {
-              disconnect();
-              setOpen(false);
-            }}
-            aria-label="Disconnect wallet"
+            onClick={() => { disconnect(); setOpen(false); }}
+            aria-label="Disconnect active wallet"
             className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
           >
             <LogOut aria-hidden="true" className="h-4 w-4" />
             Disconnect
           </button>
+
+          {/* Disconnect all */}
+          {wallets.length > 1 && (
+            <button
+              role="menuitem"
+              tabIndex={0}
+              onClick={() => { disconnectAll(); setOpen(false); }}
+              aria-label="Disconnect all wallets"
+              className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-destructive/80 hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
+            >
+              <LogOut aria-hidden="true" className="h-4 w-4" />
+              Disconnect all
+            </button>
+          )}
         </div>
       )}
     </div>
   );
 }
-
-

--- a/components/chart/CandlestickChart.tsx
+++ b/components/chart/CandlestickChart.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface Candle {
+  open: number;
+  close: number;
+  high: number;
+  low: number;
+}
+
+interface CandlestickChartProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+function deriveCandles(values: number[]): Candle[] {
+  return values.map((v, i) => {
+    const open = i === 0 ? v : values[i - 1];
+    const close = v;
+    const range = Math.abs(close - open);
+    const wick = range * 0.3 + 0.05;
+    return {
+      open,
+      close,
+      high: Math.max(open, close) + wick,
+      low: Math.min(open, close) - wick,
+    };
+  });
+}
+
+export function CandlestickChart({
+  data,
+  width = 120,
+  height = 40,
+  className = "",
+}: CandlestickChartProps) {
+  const candles = useMemo(() => (data.length ? deriveCandles(data) : []), [data]);
+
+  if (!candles.length) return null;
+
+  const allVals = candles.flatMap((c) => [c.high, c.low]);
+  const minVal = Math.min(...allVals);
+  const maxVal = Math.max(...allVals);
+  const range = maxVal - minVal || 1;
+  const pad = 3;
+  const chartW = width - pad * 2;
+  const chartH = height - pad * 2;
+
+  const toY = (v: number) => height - pad - ((v - minVal) / range) * chartH;
+
+  const gap = 1;
+  const bodyW = Math.max(2, chartW / candles.length - gap);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-label="Candlestick chart"
+      role="img"
+      className={`overflow-visible ${className}`}
+    >
+      {candles.map((c, i) => {
+        const cx = pad + (i / candles.length) * chartW + bodyW / 2;
+        const isUp = c.close >= c.open;
+        const color = isUp ? "#22c55e" : "#ef4444";
+        const bodyTop = toY(Math.max(c.open, c.close));
+        const bodyBottom = toY(Math.min(c.open, c.close));
+        const bodyH = Math.max(1, bodyBottom - bodyTop);
+
+        return (
+          <g key={i}>
+            <line x1={cx} y1={toY(c.high)} x2={cx} y2={toY(c.low)} stroke={color} strokeWidth={1} />
+            <rect
+              x={cx - bodyW / 2}
+              y={bodyTop}
+              width={bodyW}
+              height={bodyH}
+              fill={isUp ? color : "none"}
+              stroke={color}
+              strokeWidth={1}
+            />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/hooks/useWallet.ts
+++ b/hooks/useWallet.ts
@@ -31,9 +31,13 @@ export function useWallet() {
   const {
     publicKey,
     isConnected: connected,
+    wallets,
+    activePublicKey,
     setPublicKey,
     setConnected,
     disconnect,
+    setActiveWallet,
+    disconnectAll,
   } = useWalletStore();
   const [isConnecting, setIsConnecting] = useState(false);
   const [isSigning, setIsSigning] = useState(false);
@@ -114,8 +118,49 @@ export function useWallet() {
     }
   }
 
+  async function connectAnother() {
+    try {
+      setIsConnecting(true);
+      setConnectError(null);
+      const connectedResponse = await isConnected();
+      if (!connectedResponse?.isConnected) {
+        walletToast.notFound();
+        setConnectError("not_found");
+        return;
+      }
+      await requestAccess();
+      const result = await getAddress();
+      const key = typeof result === "string" ? result : result.address;
+      setPublicKey(key);
+      walletToast.connected(key);
+      analyticsService.track("wallet_connected", { wallet_type: "freighter" });
+      window.dispatchEvent(new CustomEvent("wallet-connected", { detail: { publicKey: key } }));
+    } catch (err) {
+      if (isUserRejection(err)) {
+        walletToast.denied();
+      } else {
+        walletToast.connectError();
+        setConnectError("error");
+        console.error(err);
+      }
+    } finally {
+      setIsConnecting(false);
+    }
+  }
+
+  function switchWallet(key: string) {
+    setActiveWallet(key);
+    window.dispatchEvent(new CustomEvent("wallet-connected", { detail: { publicKey: key } }));
+  }
+
   function disconnectWallet() {
     disconnect();
+    walletToast.disconnected();
+    window.dispatchEvent(new CustomEvent("wallet-disconnected"));
+  }
+
+  function disconnectAllWallets() {
+    disconnectAll();
     walletToast.disconnected();
     window.dispatchEvent(new CustomEvent("wallet-disconnected"));
   }
@@ -123,8 +168,13 @@ export function useWallet() {
   return {
     publicKey,
     connected,
+    wallets,
+    activePublicKey,
     connect,
+    connectAnother,
+    switchWallet,
     disconnect: disconnectWallet,
+    disconnectAll: disconnectAllWallets,
     sign,
     isConnecting,
     isSigning,

--- a/store/useChartStyleStore.ts
+++ b/store/useChartStyleStore.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ChartStyle = "line" | "candlestick";
+
+interface ChartStyleState {
+  chartStyle: ChartStyle;
+  setChartStyle: (style: ChartStyle) => void;
+}
+
+export const useChartStyleStore = create<ChartStyleState>()(
+  persist(
+    (set) => ({
+      chartStyle: "line",
+      setChartStyle: (chartStyle) => set({ chartStyle }),
+    }),
+    { name: "chart-style-store" }
+  )
+);

--- a/store/useSignalFilterStore.ts
+++ b/store/useSignalFilterStore.ts
@@ -12,12 +12,22 @@ export const SORT_ORDER_LABELS: Record<FeedSortOrder, string> = {
   confidence: "Confidence",
 };
 
+export interface FilterPreset {
+  name: string;
+  direction: FilterDirection;
+  asset: string;
+  provider: string;
+  bookmarkedOnly: boolean;
+  sortOrder: FeedSortOrder;
+}
+
 interface SignalFilterState {
   direction: FilterDirection;
   asset: string;
   provider: string;
   bookmarkedOnly: boolean;
   sortOrder: FeedSortOrder;
+  presets: FilterPreset[];
   _hasHydrated: boolean;
   setHasHydrated: (hydrated: boolean) => void;
   setDirection: (d: FilterDirection) => void;
@@ -25,17 +35,21 @@ interface SignalFilterState {
   setProvider: (p: string) => void;
   setBookmarkedOnly: (selected: boolean) => void;
   setSortOrder: (o: FeedSortOrder) => void;
+  savePreset: (name: string) => void;
+  applyPreset: (name: string) => void;
+  deletePreset: (name: string) => void;
   reset: () => void;
 }
 
 export const useSignalFilterStore = create<SignalFilterState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       direction: "ALL",
       asset: "",
       provider: "",
       bookmarkedOnly: false,
       sortOrder: "latest",
+      presets: [],
       _hasHydrated: false,
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
       setDirection: (direction) => set({ direction }),
@@ -43,6 +57,32 @@ export const useSignalFilterStore = create<SignalFilterState>()(
       setProvider: (provider) => set({ provider }),
       setBookmarkedOnly: (selected) => set({ bookmarkedOnly: selected }),
       setSortOrder: (sortOrder) => set({ sortOrder }),
+      savePreset: (name) => {
+        const { direction, asset, provider, bookmarkedOnly, sortOrder, presets } = get();
+        const preset: FilterPreset = { name, direction, asset, provider, bookmarkedOnly, sortOrder };
+        const existing = presets.findIndex((p) => p.name === name);
+        if (existing >= 0) {
+          const updated = [...presets];
+          updated[existing] = preset;
+          set({ presets: updated });
+        } else {
+          set({ presets: [...presets, preset] });
+        }
+      },
+      applyPreset: (name) => {
+        const preset = get().presets.find((p) => p.name === name);
+        if (!preset) return;
+        set({
+          direction: preset.direction,
+          asset: preset.asset,
+          provider: preset.provider,
+          bookmarkedOnly: preset.bookmarkedOnly,
+          sortOrder: preset.sortOrder,
+        });
+      },
+      deletePreset: (name) => {
+        set({ presets: get().presets.filter((p) => p.name !== name) });
+      },
       reset: () =>
         set({
           direction: "ALL",

--- a/store/useWalletStore.ts
+++ b/store/useWalletStore.ts
@@ -1,10 +1,22 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+export interface ConnectedWallet {
+  publicKey: string;
+}
+
 interface WalletState {
+  wallets: ConnectedWallet[];
+  activePublicKey: string | null;
+  // Backward-compat fields kept in sync
   publicKey: string | null;
   isConnected: boolean;
   network: string;
+  addWallet: (key: string) => void;
+  setActiveWallet: (key: string) => void;
+  removeWallet: (key: string) => void;
+  disconnectAll: () => void;
+  // Backward-compat setters
   setPublicKey: (key: string | null) => void;
   setConnected: (connected: boolean) => void;
   disconnect: () => void;
@@ -12,13 +24,74 @@ interface WalletState {
 
 export const useWalletStore = create<WalletState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
+      wallets: [],
+      activePublicKey: null,
       publicKey: null,
       isConnected: false,
       network: "TESTNET",
-      setPublicKey: (key) => set({ publicKey: key }),
-      setConnected: (connected) => set({ isConnected: connected }),
-      disconnect: () => set({ publicKey: null, isConnected: false }),
+
+      addWallet: (key) =>
+        set((state) => {
+          if (state.wallets.some((w) => w.publicKey === key)) {
+            return { activePublicKey: key, publicKey: key, isConnected: true };
+          }
+          const wallets = [...state.wallets, { publicKey: key }];
+          return { wallets, activePublicKey: key, publicKey: key, isConnected: true };
+        }),
+
+      setActiveWallet: (key) =>
+        set((state) => {
+          if (!state.wallets.some((w) => w.publicKey === key)) return {};
+          return { activePublicKey: key, publicKey: key };
+        }),
+
+      removeWallet: (key) =>
+        set((state) => {
+          const wallets = state.wallets.filter((w) => w.publicKey !== key);
+          const activePublicKey =
+            state.activePublicKey === key
+              ? (wallets[0]?.publicKey ?? null)
+              : state.activePublicKey;
+          return {
+            wallets,
+            activePublicKey,
+            publicKey: activePublicKey,
+            isConnected: wallets.length > 0,
+          };
+        }),
+
+      disconnectAll: () =>
+        set({ wallets: [], activePublicKey: null, publicKey: null, isConnected: false }),
+
+      // Backward compat: setPublicKey adds wallet and makes it active
+      setPublicKey: (key) => {
+        if (key === null) {
+          get().disconnect();
+        } else {
+          get().addWallet(key);
+        }
+      },
+
+      // Backward compat: setConnected(false) disconnects active
+      setConnected: (connected) => {
+        if (!connected) get().disconnect();
+      },
+
+      // Backward compat: disconnect removes the active wallet
+      disconnect: () =>
+        set((state) => {
+          const key = state.activePublicKey;
+          if (!key) return {};
+          const wallets = state.wallets.filter((w) => w.publicKey !== key);
+          const activePublicKey = wallets[0]?.publicKey ?? null;
+          return {
+            wallets,
+            activePublicKey,
+            publicKey: activePublicKey,
+            isConnected: wallets.length > 0,
+          };
+        }),
     }),
     { name: "wallet-store" }
   )


### PR DESCRIPTION
## Summary

- **#327 — Command Palette**: `Cmd/Ctrl+K` triggers a fuzzy-search palette covering all app routes and quick actions (toggle theme, connect wallet). Full keyboard navigation (↑↓ / Enter / Escape) and ARIA roles.
- **#328 — Signal filter presets**: Users can save the current filter state under a name, apply saved presets in one click, and delete them. Presets are persisted via Zustand `persist`.
- **#329 — Candlestick chart toggle**: Each SignalCard now has a button to switch the sparkline between line and candlestick style. The preference is persisted globally via `useChartStyleStore`.
- **#330 — Multi-wallet support**: The wallet store tracks a list of connected wallets with an active pointer. The dropdown shows all connected wallets, lets the user switch active, add another via Freighter, disconnect one, or disconnect all.

## Test plan

- [ ] Press `Ctrl+K` (or `Cmd+K` on Mac) — palette opens; type to fuzzy-filter; arrow keys navigate; Enter navigates/runs action; Escape closes
- [ ] In signal filters panel, save a preset, apply it, delete it; verify state persists across reload
- [ ] On any SignalCard with ROI history, click the chart-style toggle — switches between line and candlestick; verify style persists after page reload
- [ ] Connect a wallet, open dropdown → "Connect another wallet" → connect again (or reject); verify wallet list, active highlight, switch, disconnect one, disconnect all

closes #327 
closes #328 
closes #329 
closes #330 