### PR TITLE
feat: backtest presets, demo countdown/reset, referral UTM generator (#339 #345 #346 #349)

### DIFF
--- a/app/referral/page.tsx
+++ b/app/referral/page.tsx
@@ -2,45 +2,108 @@
 
 import React, { useState } from 'react'
 
-export default function ReferralPage(){
+const BASE_REFERRAL_URL = 'https://app.example.com/referral/ABC123'
+
+export const UTM_CHANNELS = [
+  { key: 'twitter',  label: 'Twitter',  source: 'twitter',  medium: 'social' },
+  { key: 'telegram', label: 'Telegram', source: 'telegram', medium: 'social' },
+  { key: 'whatsapp', label: 'WhatsApp', source: 'whatsapp', medium: 'messaging' },
+  { key: 'email',    label: 'Email',    source: 'email',    medium: 'email' },
+] as const
+
+export type ChannelKey = typeof UTM_CHANNELS[number]['key']
+
+export function buildReferralLink(baseUrl: string, channel: ChannelKey): string {
+  const ch = UTM_CHANNELS.find((c) => c.key === channel)
+  if (!ch) return baseUrl
+  const params = new URLSearchParams({
+    utm_source:   ch.source,
+    utm_medium:   ch.medium,
+    utm_campaign: 'referral',
+    utm_content:  channel,
+  })
+  return `${baseUrl}?${params.toString()}`
+}
+
+export default function ReferralPage() {
   const [copied, setCopied] = useState(false)
-  const referral = 'https://app.example.com/referral/ABC123'
+  const [selectedChannel, setSelectedChannel] = useState<ChannelKey>('twitter')
   const referrals = [
-    { id: 'r1', email: 'alice@example.com', status: 'verified', earned: 10 },
-    { id: 'r2', email: 'bob@example.com', status: 'pending', earned: 0 },
+    { id: 'r1', email: 'alice@example.com', status: 'verified', earned: 10, channel: 'twitter' },
+    { id: 'r2', email: 'bob@example.com',   status: 'pending',  earned: 0,  channel: 'telegram' },
   ]
 
-  const copy = async ()=>{
-    await navigator.clipboard.writeText(referral)
+  const generatedLink = buildReferralLink(BASE_REFERRAL_URL, selectedChannel)
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(generatedLink)
     setCopied(true)
-    setTimeout(()=>setCopied(false),2000)
+    setTimeout(() => setCopied(false), 2000)
   }
+
+  const channelCounts = referrals.reduce<Record<string, number>>((acc, r) => {
+    acc[r.channel] = (acc[r.channel] ?? 0) + 1
+    return acc
+  }, {})
 
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Referral Program</h1>
+
+      {/* UTM link generator */}
       <div className="bg-white/5 p-4 rounded mb-4">
-        <p className="text-sm text-gray-400 mb-2">Your referral link</p>
-        <div className="flex gap-2 items-center">
-          <input readOnly value={referral} className="flex-1 bg-black/20 px-3 py-2 rounded" />
-          <button onClick={copy} className="px-3 py-2 bg-purple-500 rounded">{copied ? 'Copied' : 'Copy'}</button>
+        <p className="text-sm text-gray-400 mb-2">Generate referral link with UTM tracking</p>
+
+        {/* Channel selector */}
+        <div className="flex flex-wrap gap-2 mb-3" role="group" aria-label="Select channel">
+          {UTM_CHANNELS.map((ch) => (
+            <button
+              key={ch.key}
+              onClick={() => setSelectedChannel(ch.key)}
+              aria-pressed={selectedChannel === ch.key}
+              data-testid={`channel-${ch.key}`}
+              className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+                selectedChannel === ch.key
+                  ? 'bg-purple-500 text-white'
+                  : 'bg-white/10 text-gray-300 hover:bg-white/20'
+              }`}
+            >
+              {ch.label}
+            </button>
+          ))}
         </div>
-        <div className="flex gap-2 mt-3">
-          <button className="px-3 py-2 bg-blue-500 rounded">Twitter</button>
-          <button className="px-3 py-2 bg-cyan-500 rounded">Telegram</button>
-          <button className="px-3 py-2 bg-green-500 rounded">WhatsApp</button>
-          <button className="px-3 py-2 bg-gray-500 rounded">Email</button>
+
+        {/* Generated link display + copy */}
+        <div className="flex gap-2 items-center">
+          <input
+            readOnly
+            value={generatedLink}
+            className="flex-1 bg-black/20 px-3 py-2 rounded text-sm font-mono"
+            data-testid="utm-link-input"
+            aria-label="Generated referral link with UTM parameters"
+          />
+          <button
+            onClick={copy}
+            className="px-3 py-2 bg-purple-500 hover:bg-purple-600 rounded text-sm transition-colors"
+            data-testid="copy-link-btn"
+            aria-label="Copy referral link"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
         </div>
       </div>
 
-      <div className="bg-white/5 p-4 rounded">
+      {/* Referral list */}
+      <div className="bg-white/5 p-4 rounded mb-4">
         <h2 className="font-semibold mb-2">Active Referrals</h2>
         <div className="space-y-2">
-          {referrals.map(r=> (
+          {referrals.map((r) => (
             <div key={r.id} className="flex items-center justify-between p-2 bg-black/20 rounded">
               <div>
                 <div className="text-sm">{r.email}</div>
-                <div className="text-xs text-gray-400">Status: {r.status}</div>
+                <div className="text-xs text-gray-400">
+                  Status: {r.status} · Channel: {r.channel}
+                </div>
               </div>
               <div className="text-sm">Earned: ${r.earned}</div>
             </div>
@@ -48,7 +111,25 @@ export default function ReferralPage(){
         </div>
       </div>
 
-      <div className="mt-4 text-sm text-gray-400">By participating you agree to the <a href="#" className="text-purple-400">Referral Terms & Conditions</a>.</div>
+      {/* Channel performance breakdown */}
+      <div className="bg-white/5 p-4 rounded mb-4">
+        <h2 className="font-semibold mb-2">Performance by Channel</h2>
+        <div className="space-y-1">
+          {UTM_CHANNELS.map((ch) => (
+            <div key={ch.key} className="flex items-center justify-between text-sm">
+              <span className="text-gray-300">{ch.label}</span>
+              <span className="text-gray-400" data-testid={`channel-count-${ch.key}`}>
+                {channelCounts[ch.key] ?? 0} referral{(channelCounts[ch.key] ?? 0) !== 1 ? 's' : ''}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 text-sm text-gray-400">
+        By participating you agree to the{' '}
+        <a href="#" className="text-purple-400">Referral Terms &amp; Conditions</a>.
+      </div>
     </div>
   )
 }

--- a/components/BacktestTool.tsx
+++ b/components/BacktestTool.tsx
@@ -2,8 +2,9 @@
 
 import React, { useState } from 'react'
 import { runBacktest, type BacktestParams, type BacktestResult } from '@/lib/backtest'
-import { Download } from 'lucide-react'
+import { Download, Save, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useBacktestPresetsStore } from '@/store/useBacktestPresetsStore'
 
 function downloadFile(content: string, filename: string, mime: string) {
   const blob = new Blob([content], { type: mime })
@@ -45,6 +46,10 @@ export default function BacktestTool() {
   const [result, setResult] = useState<BacktestResult | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [presetName, setPresetName] = useState('')
+  const [showSaveInput, setShowSaveInput] = useState(false)
+
+  const { presets, savePreset, deletePreset } = useBacktestPresetsStore()
 
   const params: BacktestParams = { from, to, signals: selected, slippageBps, feeBps }
 
@@ -61,8 +66,53 @@ export default function BacktestTool() {
     }
   }
 
+  function handleSavePreset() {
+    if (!presetName.trim()) return
+    savePreset(presetName.trim(), params)
+    setPresetName('')
+    setShowSaveInput(false)
+  }
+
+  function handleLoadPreset(id: string) {
+    const preset = presets.find((p) => p.id === id)
+    if (!preset) return
+    setFrom(preset.params.from)
+    setTo(preset.params.to)
+    setSelected(preset.params.signals)
+    setSlippageBps(preset.params.slippageBps ?? 10)
+    setFeeBps(preset.params.feeBps ?? 10)
+  }
+
   return (
     <div className="bg-surface border border-border rounded-lg p-4">
+      {/* Presets */}
+      {presets.length > 0 && (
+        <div className="mb-4">
+          <label className="text-xs text-foreground-muted block mb-1">Load Preset</label>
+          <div className="flex flex-wrap gap-2">
+            {presets.map((p) => (
+              <div key={p.id} className="flex items-center gap-1">
+                <button
+                  onClick={() => handleLoadPreset(p.id)}
+                  className="text-xs px-2 py-1 bg-white/10 hover:bg-white/20 rounded transition-colors"
+                  data-testid={`preset-load-${p.id}`}
+                >
+                  {p.name}
+                </button>
+                <button
+                  onClick={() => deletePreset(p.id)}
+                  aria-label={`Delete preset ${p.name}`}
+                  className="text-red-400 hover:text-red-300"
+                  data-testid={`preset-delete-${p.id}`}
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Inputs */}
       <div className="flex flex-wrap gap-4 mb-4">
         <div>
@@ -107,6 +157,46 @@ export default function BacktestTool() {
             className="block w-20"
           />
         </div>
+      </div>
+
+      {/* Save preset row */}
+      <div className="flex items-center gap-2 mb-4">
+        {showSaveInput ? (
+          <>
+            <input
+              type="text"
+              value={presetName}
+              onChange={(e) => setPresetName(e.target.value)}
+              placeholder="Preset name"
+              className="text-sm px-2 py-1 bg-white/10 rounded border border-white/20 focus:outline-none"
+              data-testid="preset-name-input"
+              onKeyDown={(e) => e.key === 'Enter' && handleSavePreset()}
+              autoFocus
+            />
+            <Button
+              size="sm"
+              onClick={handleSavePreset}
+              disabled={!presetName.trim()}
+              data-testid="preset-save-confirm"
+            >
+              Save
+            </Button>
+            <Button size="sm" variant="ghost" onClick={() => { setShowSaveInput(false); setPresetName('') }}>
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setShowSaveInput(true)}
+            className="gap-2"
+            data-testid="preset-save-open"
+          >
+            <Save className="h-3 w-3" />
+            Save as preset
+          </Button>
+        )}
       </div>
 
       {/* Actions */}

--- a/components/DemoModeToggle.tsx
+++ b/components/DemoModeToggle.tsx
@@ -1,12 +1,58 @@
 "use client";
 
-import { Play } from "lucide-react";
-import { useDemoModeStore, useDemoModeHydrated } from "@/store/useDemoModeStore";
+import { useEffect, useState } from "react";
+import { Play, RotateCcw } from "lucide-react";
+import {
+  useDemoModeStore,
+  useDemoModeHydrated,
+  DEMO_SESSION_DURATION_MS,
+  DEMO_WARNING_THRESHOLD_MS,
+} from "@/store/useDemoModeStore";
 import { cn } from "@/lib/utils";
 
+function formatCountdown(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
 export function DemoModeToggle({ className }: { className?: string }) {
-  const { isDemoMode, toggleDemoMode } = useDemoModeStore();
+  const { isDemoMode, toggleDemoMode, sessionStartedAt, resetDemoData } = useDemoModeStore();
   const isHydrated = useDemoModeHydrated();
+  const [remaining, setRemaining] = useState<number | null>(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  useEffect(() => {
+    if (!isDemoMode || sessionStartedAt === null) {
+      setRemaining(null);
+      return;
+    }
+
+    function tick() {
+      const elapsed = Date.now() - (sessionStartedAt as number);
+      setRemaining(Math.max(0, DEMO_SESSION_DURATION_MS - elapsed));
+    }
+
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [isDemoMode, sessionStartedAt]);
+
+  const isWarning = remaining !== null && remaining <= DEMO_WARNING_THRESHOLD_MS;
+
+  function handleResetClick() {
+    if (!confirmReset) {
+      setConfirmReset(true);
+      return;
+    }
+    resetDemoData();
+    setConfirmReset(false);
+  }
+
+  function handleResetCancel() {
+    setConfirmReset(false);
+  }
 
   // Render a stable placeholder until localStorage has been read.
   if (!isHydrated) {
@@ -22,25 +68,74 @@ export function DemoModeToggle({ className }: { className?: string }) {
   }
 
   return (
-    <button
-      onClick={toggleDemoMode}
-      aria-pressed={isDemoMode}
-      aria-label={isDemoMode ? "Exit demo mode" : "Enter demo mode"}
-      className={cn(
-        "flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring forced-color-adjust-none",
-        isDemoMode
-          ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30 forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] forced-colors:ring-[Highlight]"
-          : "bg-foreground/5 text-foreground-muted hover:bg-foreground/10 hover:text-foreground forced-colors:border forced-colors:border-[ButtonText] forced-colors:text-[ButtonText]",
-        className
-      )}
-    >
-      <Play size={12} aria-hidden="true" />
-      <span>Demo Mode</span>
-      {isDemoMode && (
-        <span className="ml-1 rounded bg-blue-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
-          ON
+    <div className={cn("flex items-center gap-2", className)}>
+      <button
+        onClick={toggleDemoMode}
+        aria-pressed={isDemoMode}
+        aria-label={isDemoMode ? "Exit demo mode" : "Enter demo mode"}
+        className={cn(
+          "flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring forced-color-adjust-none",
+          isDemoMode
+            ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30 forced-colors:bg-[Highlight] forced-colors:text-[HighlightText] forced-colors:ring-[Highlight]"
+            : "bg-foreground/5 text-foreground-muted hover:bg-foreground/10 hover:text-foreground forced-colors:border forced-colors:border-[ButtonText] forced-colors:text-[ButtonText]"
+        )}
+      >
+        <Play size={12} aria-hidden="true" />
+        <span>Demo Mode</span>
+        {isDemoMode && (
+          <span className="ml-1 rounded bg-blue-500 px-1.5 py-0.5 text-[10px] font-bold text-white">
+            ON
+          </span>
+        )}
+      </button>
+
+      {isDemoMode && remaining !== null && (
+        <span
+          data-testid="demo-countdown"
+          className={cn(
+            "text-xs font-mono px-2 py-0.5 rounded",
+            isWarning
+              ? "bg-red-500/20 text-red-400 ring-1 ring-red-500/30"
+              : "bg-white/10 text-foreground-muted"
+          )}
+          aria-label={`Demo session time remaining: ${formatCountdown(remaining)}`}
+          data-warning={isWarning}
+        >
+          {formatCountdown(remaining)}
         </span>
       )}
-    </button>
+
+      {isDemoMode && (
+        confirmReset ? (
+          <span className="flex items-center gap-1 text-xs">
+            <span className="text-yellow-400">Reset demo data?</span>
+            <button
+              onClick={handleResetClick}
+              className="px-2 py-0.5 bg-red-500/80 hover:bg-red-500 text-white rounded text-xs"
+              data-testid="demo-reset-confirm"
+            >
+              Confirm
+            </button>
+            <button
+              onClick={handleResetCancel}
+              className="px-2 py-0.5 bg-white/10 hover:bg-white/20 rounded text-xs"
+              data-testid="demo-reset-cancel"
+            >
+              Cancel
+            </button>
+          </span>
+        ) : (
+          <button
+            onClick={handleResetClick}
+            aria-label="Reset demo data"
+            className="flex items-center gap-1 rounded-full px-2 py-1 text-xs text-foreground-muted hover:text-foreground bg-foreground/5 hover:bg-foreground/10 transition-colors forced-color-adjust-none"
+            data-testid="demo-reset-open"
+          >
+            <RotateCcw size={11} aria-hidden="true" />
+            Reset Data
+          </button>
+        )
+      )}
+    </div>
   );
 }

--- a/store/__tests__/useBacktestPresetsStore.test.ts
+++ b/store/__tests__/useBacktestPresetsStore.test.ts
@@ -1,0 +1,91 @@
+import { useBacktestPresetsStore } from "@/store/useBacktestPresetsStore";
+import type { BacktestParams } from "@/lib/backtest";
+
+const SAMPLE_PARAMS: BacktestParams = {
+  from: "2023-01-01",
+  to: "2023-12-31",
+  signals: ["providerA", "signalX"],
+  slippageBps: 10,
+  feeBps: 15,
+};
+
+describe("useBacktestPresetsStore – saving presets", () => {
+  beforeEach(() => {
+    useBacktestPresetsStore.setState({ presets: [] });
+  });
+
+  it("starts with no presets", () => {
+    expect(useBacktestPresetsStore.getState().presets).toHaveLength(0);
+  });
+
+  it("saves a preset under the given name", () => {
+    useBacktestPresetsStore.getState().savePreset("My Strategy", SAMPLE_PARAMS);
+    const { presets } = useBacktestPresetsStore.getState();
+    expect(presets).toHaveLength(1);
+    expect(presets[0].name).toBe("My Strategy");
+  });
+
+  it("stores the full param set in the preset", () => {
+    useBacktestPresetsStore.getState().savePreset("Q1 Run", SAMPLE_PARAMS);
+    const { params } = useBacktestPresetsStore.getState().presets[0];
+    expect(params.from).toBe("2023-01-01");
+    expect(params.to).toBe("2023-12-31");
+    expect(params.signals).toEqual(["providerA", "signalX"]);
+    expect(params.slippageBps).toBe(10);
+    expect(params.feeBps).toBe(15);
+  });
+
+  it("accumulates multiple presets", () => {
+    useBacktestPresetsStore.getState().savePreset("First", SAMPLE_PARAMS);
+    useBacktestPresetsStore.getState().savePreset("Second", { ...SAMPLE_PARAMS, from: "2024-01-01" });
+    expect(useBacktestPresetsStore.getState().presets).toHaveLength(2);
+  });
+});
+
+describe("useBacktestPresetsStore – listing presets", () => {
+  beforeEach(() => {
+    useBacktestPresetsStore.setState({ presets: [] });
+    useBacktestPresetsStore.getState().savePreset("Alpha", SAMPLE_PARAMS);
+    useBacktestPresetsStore.getState().savePreset("Beta", { ...SAMPLE_PARAMS, feeBps: 20 });
+  });
+
+  it("lists all saved presets", () => {
+    const names = useBacktestPresetsStore.getState().presets.map((p) => p.name);
+    expect(names).toContain("Alpha");
+    expect(names).toContain("Beta");
+  });
+
+  it("each preset has a unique id", () => {
+    const ids = useBacktestPresetsStore.getState().presets.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("useBacktestPresetsStore – reloading a preset", () => {
+  beforeEach(() => {
+    useBacktestPresetsStore.setState({ presets: [] });
+    useBacktestPresetsStore.getState().savePreset("Reload Test", SAMPLE_PARAMS);
+  });
+
+  it("preset params can be retrieved by id for reloading into form", () => {
+    const preset = useBacktestPresetsStore.getState().presets[0];
+    expect(preset.params).toEqual(SAMPLE_PARAMS);
+  });
+
+  it("deletes a preset by id", () => {
+    const { presets } = useBacktestPresetsStore.getState();
+    const id = presets[0].id;
+    useBacktestPresetsStore.getState().deletePreset(id);
+    expect(useBacktestPresetsStore.getState().presets).toHaveLength(0);
+  });
+
+  it("only removes the targeted preset, leaving others intact", () => {
+    useBacktestPresetsStore.getState().savePreset("Keep This", { ...SAMPLE_PARAMS, feeBps: 99 });
+    const all = useBacktestPresetsStore.getState().presets;
+    const idToRemove = all[0].id;
+    useBacktestPresetsStore.getState().deletePreset(idToRemove);
+    const remaining = useBacktestPresetsStore.getState().presets;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].name).toBe("Keep This");
+  });
+});

--- a/store/useBacktestPresetsStore.ts
+++ b/store/useBacktestPresetsStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+import type { BacktestParams } from "@/lib/backtest"
+
+export interface BacktestPreset {
+  id: string
+  name: string
+  params: BacktestParams
+  createdAt: number
+}
+
+interface BacktestPresetsState {
+  presets: BacktestPreset[]
+  savePreset: (name: string, params: BacktestParams) => void
+  deletePreset: (id: string) => void
+}
+
+export const useBacktestPresetsStore = create<BacktestPresetsState>()(
+  persist(
+    (set) => ({
+      presets: [],
+      savePreset: (name, params) =>
+        set((state) => ({
+          presets: [
+            ...state.presets,
+            { id: `${name}-${state.presets.length}`, name, params, createdAt: Date.now() },
+          ],
+        })),
+      deletePreset: (id) =>
+        set((state) => ({
+          presets: state.presets.filter((p) => p.id !== id),
+        })),
+    }),
+    { name: "backtest-presets-store" }
+  )
+)

--- a/store/useDemoModeStore.ts
+++ b/store/useDemoModeStore.ts
@@ -1,12 +1,31 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+export const DEMO_SESSION_DURATION_MS = 30 * 60 * 1000; // 30 minutes
+export const DEMO_WARNING_THRESHOLD_MS = 5 * 60 * 1000;  // warn at 5 minutes left
+
+export interface SimulatedTrade {
+  id: string;
+  pair: string;
+  amount: number;
+  pnl: number;
+  timestamp: number;
+}
+
+const DEFAULT_DEMO_TRADES: SimulatedTrade[] = [
+  { id: "demo-1", pair: "XLM/USDC", amount: 100, pnl: 4.2, timestamp: 0 },
+  { id: "demo-2", pair: "BTC/XLM", amount: 50, pnl: -1.8, timestamp: 0 },
+];
+
 export interface DemoState {
   isDemoMode: boolean;
   _hasHydrated: boolean;
+  sessionStartedAt: number | null;
+  demoTrades: SimulatedTrade[];
   setHasHydrated: (hydrated: boolean) => void;
   toggleDemoMode: () => void;
   setDemoMode: (enabled: boolean) => void;
+  resetDemoData: () => void;
 }
 
 export const useDemoModeStore = create<DemoState>()(
@@ -14,9 +33,27 @@ export const useDemoModeStore = create<DemoState>()(
     (set) => ({
       isDemoMode: false,
       _hasHydrated: false,
+      sessionStartedAt: null,
+      demoTrades: [...DEFAULT_DEMO_TRADES],
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
-      toggleDemoMode: () => set((state) => ({ isDemoMode: !state.isDemoMode })),
-      setDemoMode: (enabled) => set({ isDemoMode: enabled }),
+      toggleDemoMode: () =>
+        set((state) => {
+          const enabling = !state.isDemoMode;
+          return {
+            isDemoMode: enabling,
+            sessionStartedAt: enabling ? Date.now() : null,
+          };
+        }),
+      setDemoMode: (enabled) =>
+        set((state) => ({
+          isDemoMode: enabled,
+          sessionStartedAt: enabled && !state.isDemoMode ? Date.now() : enabled ? state.sessionStartedAt : null,
+        })),
+      resetDemoData: () =>
+        set({
+          demoTrades: [...DEFAULT_DEMO_TRADES],
+          sessionStartedAt: Date.now(),
+        }),
     }),
     {
       name: "demo-mode-store",


### PR DESCRIPTION
## Summary

### closes #339 — Backtest parameter presets

- New `useBacktestPresetsStore` (zustand + persist) stores named parameter sets in localStorage across sessions.
- `BacktestTool` gains a **Save as preset** inline flow (name input → Save/Cancel) and a **Load Preset** chip row where each preset can be loaded with one click or deleted individually.
- Unit tests in `store/__tests__/useBacktestPresetsStore.test.ts` cover saving, listing (unique IDs, multiple accumulation), and reloading/deleting presets.

### closes #345 — Demo-mode session expiry countdown

- `DemoModeToggle` now renders a live `mm:ss` countdown (`data-testid="demo-countdown"`) that ticks every second via `setInterval`.
- When `remaining ≤ DEMO_WARNING_THRESHOLD_MS` (5 min), the badge switches to a red warning style (`data-warning={true}`).
- Countdown resets naturally when `resetDemoData()` refreshes `sessionStartedAt`.

### closes #346 — Dedicated demo-data reset action

- A **Reset Data** button (`data-testid="demo-reset-open"`) is shown only while demo mode is active, distinct from the on/off toggle.
- Clicking it enters a confirmation state showing **Confirm** (`data-testid="demo-reset-confirm"`) and **Cancel** (`data-testid="demo-reset-cancel"`), guarding against accidental resets.
- Confirming calls `resetDemoData()` in `useDemoModeStore`, which restores `DEFAULT_DEMO_TRADES` and refreshes `sessionStartedAt`.

### closes #349 — Referral link UTM-parameter generator

- `UTM_CHANNELS` constant defines Twitter, Telegram, WhatsApp, and Email with their `utm_source` and `utm_medium` values.
- `buildReferralLink(baseUrl, channel)` appends `utm_source`, `utm_medium`, `utm_campaign=referral`, and `utm_content=<channel>` via `URLSearchParams`.
- Channel selector updates the generated link in real time; a **Copy** button writes it to the clipboard with transient "Copied!" feedback.
- A **Performance by Channel** section in the referral dashboard counts referrals per `utm_content` channel, enabling channel-level attribution.

## Test plan

- [ ] Save a backtest preset, reload the page, verify it persists; load it back into the form; delete it.
- [ ] Enable demo mode and confirm the countdown ticks down; let it approach 5 min and verify the red warning state.
- [ ] Click **Reset Data**, verify the confirmation step, confirm and check that demo trades are restored to defaults.
- [ ] On the referral page, switch channels and verify the UTM parameters change; copy the link and paste it.
- [ ] Run `jest store/__tests__/useBacktestPresetsStore.test.ts` — all tests should pass.