### PR TITLE
feat: add bookmark folders/collections for grouping saved signals

### DIFF
--- a/components/bookmarks/BookmarksPage.tsx
+++ b/components/bookmarks/BookmarksPage.tsx
@@ -1,11 +1,25 @@
 "use client";
 
+import { useState, type FormEvent } from "react";
 import Link from "next/link";
-import { ArrowLeft, BookmarkX, RefreshCw } from "lucide-react";
+import {
+  ArrowLeft,
+  BookmarkX,
+  Folder as FolderIcon,
+  FolderPlus,
+  Pencil,
+  Trash2,
+  RefreshCw,
+  Plus,
+  X,
+  Check,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SignalCard } from "@/components/SignalCard";
-import { useBookmarkStore, useBookmarkHydrated } from "@/store/useBookmarkStore";
+import { useBookmarkStore, useBookmarkHydrated, type BookmarkFolder } from "@/store/useBookmarkStore";
+import { useBookmarkActions } from "@/hooks/useBookmarkActions";
 import { usePortfolio } from "@/hooks/usePortfolio";
+import { cn } from "@/lib/utils";
 import type { Signal } from "@/lib/signals";
 
 interface BookmarksPageProps {
@@ -26,8 +40,8 @@ function BookmarksEmptyState() {
       <div className="max-w-sm">
         <p className="text-lg font-semibold text-white">No bookmarks yet</p>
         <p className="mt-1.5 text-sm text-foreground-muted">
-          Save signals from the main feed to build a short list here. You can unbookmark
-          them at any time and bring them back with undo.
+          Save signals from the main feed to build a short list here. You can organize
+          them into folders for different strategies.
         </p>
       </div>
 
@@ -62,13 +76,265 @@ function BookmarksSkeleton() {
   );
 }
 
+function CreateFolderForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (trimmed) {
+      onSubmit(trimmed);
+      setName("");
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <input
+        autoFocus
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Folder name"
+        className="flex h-8 w-full rounded-md border border-white/10 bg-white/5 px-2 text-sm text-foreground placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-sky-400"
+        maxLength={40}
+      />
+      <button
+        type="submit"
+        disabled={!name.trim()}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-sky-400 hover:bg-white/10 disabled:opacity-40"
+        aria-label="Create folder"
+      >
+        <Check className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted hover:bg-white/10"
+        aria-label="Cancel"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </form>
+  );
+}
+
+function RenameFolderForm({
+  initialName,
+  onSubmit,
+  onCancel,
+}: {
+  initialName: string;
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(initialName);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (trimmed && trimmed !== initialName) {
+      onSubmit(trimmed);
+    } else {
+      onCancel();
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-center gap-2">
+      <input
+        autoFocus
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Folder name"
+        className="flex h-8 w-full rounded-md border border-white/10 bg-white/5 px-2 text-sm text-foreground placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-sky-400"
+        maxLength={40}
+      />
+      <button
+        type="submit"
+        disabled={!name.trim() || name.trim() === initialName}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-sky-400 hover:bg-white/10 disabled:opacity-40"
+        aria-label="Save name"
+      >
+        <Check className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-foreground-muted hover:bg-white/10"
+        aria-label="Cancel"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </form>
+  );
+}
+
+function FolderList({
+  folders,
+  selectedFolderId,
+  onSelectFolder,
+  onRenameFolder,
+  onDeleteFolder,
+  onCreateFolder,
+}: {
+  folders: BookmarkFolder[];
+  selectedFolderId: string | null;
+  onSelectFolder: (id: string | null) => void;
+  onRenameFolder: (id: string, name: string) => void;
+  onDeleteFolder: (id: string) => void;
+  onCreateFolder: (name: string) => void;
+}) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between px-1 pb-1">
+        <span className="text-xs uppercase tracking-wider text-foreground-muted">Folders</span>
+        <button
+          onClick={() => setIsCreating(true)}
+          className="inline-flex h-6 w-6 items-center justify-center rounded text-foreground-muted hover:bg-white/10 hover:text-foreground"
+          aria-label="Create folder"
+        >
+          <FolderPlus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {isCreating && (
+        <div className="px-1 pb-1">
+          <CreateFolderForm
+            onSubmit={(name) => {
+              onCreateFolder(name);
+              setIsCreating(false);
+            }}
+            onCancel={() => setIsCreating(false)}
+          />
+        </div>
+      )}
+
+      <button
+        onClick={() => onSelectFolder(null)}
+        className={cn(
+          "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors",
+          selectedFolderId === null
+            ? "bg-sky-400/10 text-sky-400"
+            : "text-foreground-muted hover:bg-white/5 hover:text-foreground"
+        )}
+      >
+        <FolderIcon className="h-4 w-4 shrink-0" />
+        <span>All bookmarks</span>
+      </button>
+
+      {folders.map((folder) => (
+        <div key={folder.id} className="group relative">
+          {renamingId === folder.id ? (
+            <div className="px-1">
+              <RenameFolderForm
+                initialName={folder.name}
+                onSubmit={(name) => {
+                  onRenameFolder(folder.id, name);
+                  setRenamingId(null);
+                }}
+                onCancel={() => setRenamingId(null)}
+              />
+            </div>
+          ) : (
+            <button
+              onClick={() => onSelectFolder(folder.id)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors",
+                selectedFolderId === folder.id
+                  ? "bg-sky-400/10 text-sky-400"
+                  : "text-foreground-muted hover:bg-white/5 hover:text-foreground"
+              )}
+            >
+              <FolderIcon className="h-4 w-4 shrink-0" />
+              <span className="flex-1 truncate">{folder.name}</span>
+              <span className="text-xs text-foreground-muted">{folder.signalIds.length}</span>
+              <div className="hidden gap-0.5 group-hover:flex">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setRenamingId(folder.id);
+                  }}
+                  className="inline-flex h-6 w-6 items-center justify-center rounded text-foreground-muted hover:text-foreground"
+                  aria-label={`Rename ${folder.name}`}
+                >
+                  <Pencil className="h-3 w-3" />
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDeleteFolder(folder.id);
+                  }}
+                  className="inline-flex h-6 w-6 items-center justify-center rounded text-foreground-muted hover:text-red-400"
+                  aria-label={`Delete ${folder.name}`}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </div>
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function BookmarksPage({ initialSignals }: BookmarksPageProps) {
   const bookmarks = useBookmarkStore((state) => state.bookmarks);
+  const folders = useBookmarkStore((state) => state.folders);
   const isHydrated = useBookmarkHydrated();
   const { assets } = usePortfolio();
+  const {
+    createFolder,
+    renameFolder,
+    deleteFolder,
+    assignSignalToFolder,
+    removeSignalFromFolder,
+  } = useBookmarkActions();
 
-  const bookmarkedSignals = initialSignals.filter((signal) => bookmarks.includes(signal.id));
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
+
+  const selectedFolder = selectedFolderId
+    ? folders.find((f) => f.id === selectedFolderId) ?? null
+    : null;
+
+  let filteredSignalIds: string[];
+  if (selectedFolder) {
+    filteredSignalIds = selectedFolder.signalIds.filter((id) => bookmarks.includes(id));
+  } else {
+    filteredSignalIds = bookmarks;
+  }
+
+  const bookmarkedSignals = initialSignals.filter((signal) =>
+    filteredSignalIds.includes(signal.id)
+  );
+
   const portfolioBalance = assets.reduce((sum, asset) => sum + asset.value, 0);
+
+  const handleCreateFolder = (name: string) => {
+    createFolder(name);
+  };
+
+  const handleRenameFolder = (folderId: string, name: string) => {
+    renameFolder(folderId, name);
+  };
+
+  const handleDeleteFolder = (folderId: string) => {
+    deleteFolder(folderId);
+    if (selectedFolderId === folderId) {
+      setSelectedFolderId(null);
+    }
+  };
 
   return (
     <main className="min-h-screen bg-background px-4 py-6 text-foreground sm:px-6 sm:py-8 lg:px-8">
@@ -80,8 +346,8 @@ export function BookmarksPage({ initialSignals }: BookmarksPageProps) {
               Saved signals
             </h1>
             <p className="max-w-2xl text-sm text-foreground-muted">
-              Signals you save from the main feed appear here automatically and stay in sync
-              across the app.
+              Signals you save from the main feed appear here. Organize them into folders
+              to track different strategies.
             </p>
           </div>
 
@@ -98,28 +364,97 @@ export function BookmarksPage({ initialSignals }: BookmarksPageProps) {
           </div>
         </div>
 
-        {!isHydrated ? (
-          <BookmarksSkeleton />
-        ) : bookmarkedSignals.length === 0 ? (
-          <BookmarksEmptyState />
-        ) : (
-          <div className="space-y-4">
-            {bookmarkedSignals.map((signal) => (
-              <SignalCard
-                key={signal.id}
-                signalId={signal.id}
-                pair={`${signal.ticker}/USDC`}
-                action={signal.action}
-                confidence={signal.confidence}
-                analysis={signal.details}
-                providerName={signal.provider}
-                timestamp={new Date(signal.timestamp)}
-                showPassAction={false}
-                portfolioBalance={portfolioBalance}
+        <div className="flex flex-col gap-6 lg:flex-row lg:gap-8">
+          <aside className="w-full shrink-0 lg:w-64">
+            <div className="rounded-xl border border-white/10 bg-slate-950/60 p-3">
+              <FolderList
+                folders={folders}
+                selectedFolderId={selectedFolderId}
+                onSelectFolder={setSelectedFolderId}
+                onRenameFolder={handleRenameFolder}
+                onDeleteFolder={handleDeleteFolder}
+                onCreateFolder={handleCreateFolder}
               />
-            ))}
+            </div>
+          </aside>
+
+          <div className="min-w-0 flex-1">
+            {!isHydrated ? (
+              <BookmarksSkeleton />
+            ) : bookmarkedSignals.length === 0 ? (
+              <BookmarksEmptyState />
+            ) : (
+              <div className="space-y-4">
+                {bookmarkedSignals.map((signal) => {
+                  const signalFolders = folders.filter((f) =>
+                    f.signalIds.includes(signal.id)
+                  );
+
+                  return (
+                    <div key={signal.id}>
+                      <SignalCard
+                        signalId={signal.id}
+                        pair={`${signal.ticker}/USDC`}
+                        action={signal.action}
+                        confidence={signal.confidence}
+                        analysis={signal.details}
+                        providerName={signal.provider}
+                        timestamp={new Date(signal.timestamp)}
+                        showPassAction={false}
+                        portfolioBalance={portfolioBalance}
+                      />
+                      {folders.length > 0 && (
+                        <div className="mt-1 flex flex-wrap gap-1.5 px-1">
+                          {signalFolders.map((f) => (
+                            <button
+                              key={f.id}
+                              onClick={() => removeSignalFromFolder(signal.id, f.id, f.name)}
+                              className="inline-flex items-center gap-1 rounded-full bg-sky-400/10 px-2.5 py-0.5 text-xs text-sky-400 hover:bg-sky-400/20"
+                              aria-label={`Remove from ${f.name}`}
+                            >
+                              <FolderIcon className="h-3 w-3" />
+                              {f.name}
+                              <X className="h-3 w-3" />
+                            </button>
+                          ))}
+                          {signalFolders.length < folders.length && (
+                            <div className="relative inline-flex">
+                              <select
+                                onChange={(e) => {
+                                  const folderId = e.target.value;
+                                  if (folderId) {
+                                    const folder = folders.find((f) => f.id === folderId);
+                                    if (folder) {
+                                      assignSignalToFolder(signal.id, folderId, folder.name);
+                                    }
+                                  }
+                                  e.target.value = "";
+                                }}
+                                value=""
+                                className="appearance-none rounded-full bg-white/5 px-2.5 py-0.5 pr-6 text-xs text-foreground-muted hover:bg-white/10 focus:outline-none"
+                                aria-label="Assign to folder"
+                              >
+                                <option value="">+ Folder</option>
+                                {folders
+                                  .filter((f) => !f.signalIds.includes(signal.id))
+                                  .map((f) => (
+                                    <option key={f.id} value={f.id}>
+                                      {f.name}
+                                    </option>
+                                  ))}
+                              </select>
+                              <Plus className="pointer-events-none absolute right-1.5 top-1/2 h-3 w-3 -translate-y-1/2 text-foreground-muted" />
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
-        )}
+        </div>
       </div>
     </main>
   );

--- a/hooks/useBookmarkActions.ts
+++ b/hooks/useBookmarkActions.ts
@@ -35,6 +35,11 @@ export function useBookmarkActions() {
   const removeBookmark = useBookmarkStore((state) => state.removeBookmark);
   const toggleBookmark = useBookmarkStore((state) => state.toggleBookmark);
   const hasBookmark = useBookmarkStore((state) => state.hasBookmark);
+  const createFolder = useBookmarkStore((state) => state.createFolder);
+  const renameFolder = useBookmarkStore((state) => state.renameFolder);
+  const deleteFolder = useBookmarkStore((state) => state.deleteFolder);
+  const assignSignalToFolder = useBookmarkStore((state) => state.assignSignalToFolder);
+  const removeSignalFromFolder = useBookmarkStore((state) => state.removeSignalFromFolder);
 
   const bookmark = useCallback(
     (id: string) => {
@@ -72,11 +77,72 @@ export function useBookmarkActions() {
     [bookmark, hasBookmark, unbookmark]
   );
 
+  const handleCreateFolder = useCallback(
+    (name: string) => {
+      const id = createFolder(name);
+      toast.success("Folder created", {
+        description: `"${name}" folder created.`,
+        duration: 2500,
+      });
+      return id;
+    },
+    [createFolder]
+  );
+
+  const handleRenameFolder = useCallback(
+    (folderId: string, name: string) => {
+      renameFolder(folderId, name);
+      toast.success("Folder renamed", {
+        description: `Renamed to "${name}".`,
+        duration: 2500,
+      });
+    },
+    [renameFolder]
+  );
+
+  const handleDeleteFolder = useCallback(
+    (folderId: string, folderName: string) => {
+      deleteFolder(folderId);
+      toast.info("Folder deleted", {
+        description: `"${folderName}" and its assignments were removed.`,
+        duration: 3500,
+      });
+    },
+    [deleteFolder]
+  );
+
+  const handleAssignToFolder = useCallback(
+    (signalId: string, folderId: string, folderName: string) => {
+      assignSignalToFolder(signalId, folderId);
+      toast.success("Assigned", {
+        description: `Signal added to "${folderName}".`,
+        duration: 2000,
+      });
+    },
+    [assignSignalToFolder]
+  );
+
+  const handleRemoveFromFolder = useCallback(
+    (signalId: string, folderId: string, folderName: string) => {
+      removeSignalFromFolder(signalId, folderId);
+      toast.info("Removed", {
+        description: `Signal removed from "${folderName}".`,
+        duration: 2000,
+      });
+    },
+    [removeSignalFromFolder]
+  );
+
   return {
     addBookmark: bookmark,
     removeBookmark: unbookmark,
     toggleBookmark: (id: string, label: string) => toggleBookmarkWithUndo(id, label),
     hasBookmark,
     directToggleBookmark: toggleBookmark,
+    createFolder: handleCreateFolder,
+    renameFolder: handleRenameFolder,
+    deleteFolder: handleDeleteFolder,
+    assignSignalToFolder: handleAssignToFolder,
+    removeSignalFromFolder: handleRemoveFromFolder,
   };
 }

--- a/store/__tests__/stores.test.ts
+++ b/store/__tests__/stores.test.ts
@@ -143,6 +143,112 @@ describe("useBookmarkStore", () => {
   });
 });
 
+// ── Bookmark Folders ──────────────────────────────────────────────────────────
+
+describe("bookmark folders", () => {
+  beforeEach(() => {
+    useBookmarkStore.setState({
+      bookmarks: [],
+      folders: [],
+    });
+  });
+
+  it("createFolder adds a new folder with the given name", () => {
+    const id = useBookmarkStore.getState().createFolder("Watching");
+    const folders = useBookmarkStore.getState().folders;
+    expect(folders).toHaveLength(1);
+    expect(folders[0].id).toBe(id);
+    expect(folders[0].name).toBe("Watching");
+    expect(folders[0].signalIds).toEqual([]);
+  });
+
+  it("createFolder returns a unique id each time", () => {
+    const id1 = useBookmarkStore.getState().createFolder("A");
+    const id2 = useBookmarkStore.getState().createFolder("B");
+    expect(id1).not.toBe(id2);
+    expect(useBookmarkStore.getState().folders).toHaveLength(2);
+  });
+
+  it("renameFolder updates the folder name", () => {
+    const id = useBookmarkStore.getState().createFolder("Watch");
+    useBookmarkStore.getState().renameFolder(id, "Watching");
+    const folder = useBookmarkStore.getState().folders.find((f) => f.id === id);
+    expect(folder?.name).toBe("Watching");
+  });
+
+  it("deleteFolder removes the folder", () => {
+    const id = useBookmarkStore.getState().createFolder("Temp");
+    expect(useBookmarkStore.getState().folders).toHaveLength(1);
+    useBookmarkStore.getState().deleteFolder(id);
+    expect(useBookmarkStore.getState().folders).toHaveLength(0);
+  });
+
+  it("assignSignalToFolder adds signal id to folder signalIds", () => {
+    const id = useBookmarkStore.getState().createFolder("High Conviction");
+    useBookmarkStore.getState().assignSignalToFolder("signal-1", id);
+    const folder = useBookmarkStore.getState().folders.find((f) => f.id === id);
+    expect(folder?.signalIds).toEqual(["signal-1"]);
+  });
+
+  it("assignSignalToFolder does not duplicate signal ids", () => {
+    const id = useBookmarkStore.getState().createFolder("Test");
+    useBookmarkStore.getState().assignSignalToFolder("s1", id);
+    useBookmarkStore.getState().assignSignalToFolder("s1", id);
+    const folder = useBookmarkStore.getState().folders.find((f) => f.id === id);
+    expect(folder?.signalIds).toEqual(["s1"]);
+  });
+
+  it("removeSignalFromFolder removes signal id from folder", () => {
+    const id = useBookmarkStore.getState().createFolder("Test");
+    useBookmarkStore.getState().assignSignalToFolder("s1", id);
+    useBookmarkStore.getState().assignSignalToFolder("s2", id);
+    useBookmarkStore.getState().removeSignalFromFolder("s1", id);
+    const folder = useBookmarkStore.getState().folders.find((f) => f.id === id);
+    expect(folder?.signalIds).toEqual(["s2"]);
+  });
+
+  it("getSignalsByFolder returns signal ids for the folder", () => {
+    const id = useBookmarkStore.getState().createFolder("Test");
+    useBookmarkStore.getState().assignSignalToFolder("s1", id);
+    useBookmarkStore.getState().assignSignalToFolder("s2", id);
+    const ids = useBookmarkStore.getState().getSignalsByFolder(id);
+    expect(ids).toEqual(["s1", "s2"]);
+  });
+
+  it("getSignalsByFolder returns empty array for nonexistent folder", () => {
+    const ids = useBookmarkStore.getState().getSignalsByFolder("nonexistent");
+    expect(ids).toEqual([]);
+  });
+
+  it("getFoldersForSignal returns all folders containing the signal", () => {
+    const id1 = useBookmarkStore.getState().createFolder("A");
+    const id2 = useBookmarkStore.getState().createFolder("B");
+    useBookmarkStore.getState().assignSignalToFolder("s1", id1);
+    useBookmarkStore.getState().assignSignalToFolder("s1", id2);
+    useBookmarkStore.getState().assignSignalToFolder("s2", id1);
+    const folders = useBookmarkStore.getState().getFoldersForSignal("s1");
+    expect(folders).toHaveLength(2);
+    expect(folders.map((f) => f.name).sort()).toEqual(["A", "B"]);
+  });
+
+  it("removeBookmark also removes signal from all folders", () => {
+    const id = useBookmarkStore.getState().createFolder("Test");
+    useBookmarkStore.getState().addBookmark("s1");
+    useBookmarkStore.getState().assignSignalToFolder("s1", id);
+    useBookmarkStore.getState().removeBookmark("s1");
+    const folder = useBookmarkStore.getState().folders.find((f) => f.id === id);
+    expect(folder?.signalIds).toEqual([]);
+  });
+
+  it("clearBookmarks clears folders too", () => {
+    useBookmarkStore.getState().createFolder("A");
+    useBookmarkStore.getState().createFolder("B");
+    useBookmarkStore.getState().clearBookmarks();
+    expect(useBookmarkStore.getState().bookmarks).toEqual([]);
+    expect(useBookmarkStore.getState().folders).toEqual([]);
+  });
+});
+
 // ── useTransactionStore ───────────────────────────────────────────────────────
 
 const NEW_TX: TransactionHistoryItem = {

--- a/store/useBookmarkStore.ts
+++ b/store/useBookmarkStore.ts
@@ -1,8 +1,15 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+export interface BookmarkFolder {
+  id: string;
+  name: string;
+  signalIds: string[];
+}
+
 interface BookmarkState {
   bookmarks: string[];
+  folders: BookmarkFolder[];
   _hasHydrated: boolean;
   setHasHydrated: (hydrated: boolean) => void;
   hasBookmark: (id: string) => boolean;
@@ -11,12 +18,22 @@ interface BookmarkState {
   toggleBookmark: (id: string) => void;
   setBookmarks: (ids: string[]) => void;
   clearBookmarks: () => void;
+  createFolder: (name: string) => string;
+  renameFolder: (folderId: string, name: string) => void;
+  deleteFolder: (folderId: string) => void;
+  assignSignalToFolder: (signalId: string, folderId: string) => void;
+  removeSignalFromFolder: (signalId: string, folderId: string) => void;
+  getSignalsByFolder: (folderId: string) => string[];
+  getFoldersForSignal: (signalId: string) => BookmarkFolder[];
 }
+
+let folderCounter = 0;
 
 export const useBookmarkStore = create<BookmarkState>()(
   persist(
     (set, get) => ({
       bookmarks: [],
+      folders: [],
       _hasHydrated: false,
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
       hasBookmark: (id: string) => get().bookmarks.includes(id),
@@ -29,6 +46,10 @@ export const useBookmarkStore = create<BookmarkState>()(
       removeBookmark: (id: string) =>
         set((state) => ({
           bookmarks: state.bookmarks.filter((bookmark) => bookmark !== id),
+          folders: state.folders.map((f) => ({
+            ...f,
+            signalIds: f.signalIds.filter((sid) => sid !== id),
+          })),
         })),
       toggleBookmark: (id: string) =>
         set((state) => ({
@@ -37,7 +58,47 @@ export const useBookmarkStore = create<BookmarkState>()(
             : [...state.bookmarks, id],
         })),
       setBookmarks: (ids: string[]) => set({ bookmarks: [...new Set(ids)] }),
-      clearBookmarks: () => set({ bookmarks: [] }),
+      clearBookmarks: () =>
+        set({ bookmarks: [], folders: [] }),
+      createFolder: (name: string) => {
+        const id = `folder-${++folderCounter}-${Date.now()}`;
+        set((state) => ({
+          folders: [...state.folders, { id, name, signalIds: [] }],
+        }));
+        return id;
+      },
+      renameFolder: (folderId: string, name: string) =>
+        set((state) => ({
+          folders: state.folders.map((f) =>
+            f.id === folderId ? { ...f, name } : f
+          ),
+        })),
+      deleteFolder: (folderId: string) =>
+        set((state) => ({
+          folders: state.folders.filter((f) => f.id !== folderId),
+        })),
+      assignSignalToFolder: (signalId: string, folderId: string) =>
+        set((state) => ({
+          folders: state.folders.map((f) =>
+            f.id === folderId && !f.signalIds.includes(signalId)
+              ? { ...f, signalIds: [...f.signalIds, signalId] }
+              : f
+          ),
+        })),
+      removeSignalFromFolder: (signalId: string, folderId: string) =>
+        set((state) => ({
+          folders: state.folders.map((f) =>
+            f.id === folderId
+              ? { ...f, signalIds: f.signalIds.filter((sid) => sid !== signalId) }
+              : f
+          ),
+        })),
+      getSignalsByFolder: (folderId: string) => {
+        const folder = get().folders.find((f) => f.id === folderId);
+        return folder ? folder.signalIds : [];
+      },
+      getFoldersForSignal: (signalId: string) =>
+        get().folders.filter((f) => f.signalIds.includes(signalId)),
     }),
     {
       name: "signal-bookmarks",


### PR DESCRIPTION
## Summary

Adds the ability to organize bookmarked signals into named folders (collections). Users can create, rename, and delete folders, assign signals to one or more folders, and filter the bookmarks page by folder.

## Changes

### Store (`store/useBookmarkStore.ts`)
- Added `BookmarkFolder` interface with `id`, `name`, and `signalIds` fields
- Added `folders: BookmarkFolder[]` state alongside existing `bookmarks: string[]`
- Added folder CRUD operations:
  - `createFolder(name)` – creates a new folder and returns its id
  - `renameFolder(folderId, name)` – updates folder name
  - `deleteFolder(folderId)` – removes folder
- Added signal-to-folder assignment:
  - `assignSignalToFolder(signalId, folderId)` – assigns signal to folder (no duplicates)
  - `removeSignalFromFolder(signalId, folderId)` – removes signal from folder
- Added retrieval helpers:
  - `getSignalsByFolder(folderId)` – returns signal ids for a folder
  - `getFoldersForSignal(signalId)` – returns all folders containing the signal
- Updated `removeBookmark` to also clean up signal from all folders
- Updated `clearBookmarks` to also clear folders

### Actions Hook (`hooks/useBookmarkActions.ts`)
- Added folder action wrappers with toast notifications:
  - `createFolder(name)` – toast on success
  - `renameFolder(folderId, name)` – toast on success
  - `deleteFolder(folderId, folderName)` – toast notification
  - `assignSignalToFolder(signalId, folderId, folderName)` – toast on assignment
  - `removeSignalFromFolder(signalId, folderId, folderName)` – toast on removal

### Bookmarks Page (`components/bookmarks/BookmarksPage.tsx`)
- Added sidebar with folder list (desktop: left sidebar, mobile: stacks above signals)
- "All bookmarks" default view shows every saved signal
- Clicking a folder filters signals to only those assigned to it
- Inline folder creation via `CreateFolderForm` (text input + confirm/cancel)
- Inline folder rename via `RenameFolderForm` (pre-filled text input)
- Folder delete with hover-reveal trash icon
- Per-signal folder badge chips showing assigned folders (click to remove)
- "+ Folder" dropdown to assign a signal to any folder it's not already in
- Count badges next to each folder name

### Unit Tests (`store/__tests__/stores.test.ts`)
- 12 new tests in `describe("bookmark folders")`:
  1. `createFolder` adds a folder with the given name
  2. `createFolder` returns unique ids
  3. `renameFolder` updates the folder name
  4. `deleteFolder` removes the folder
  5. `assignSignalToFolder` adds signal id to folder
  6. `assignSignalToFolder` does not duplicate signal ids
  7. `removeSignalFromFolder` removes signal id from folder
  8. `getSignalsByFolder` returns signal ids for the folder
  9. `getSignalsByFolder` returns empty for nonexistent folder
  10. `getFoldersForSignal` returns all containing folders
  11. `removeBookmark` also removes signal from all folders
  12. `clearBookmarks` clears folders too

## Files Changed

| File | Status |
|---|---|
| `store/useBookmarkStore.ts` | Modified – added folder state, CRUD, assignment |
| `hooks/useBookmarkActions.ts` | Modified – added folder action wrappers |
| `components/bookmarks/BookmarksPage.tsx` | Modified – added folder sidebar and filtering UI |
| `store/__tests__/stores.test.ts` | Modified – added 12 folder unit tests |

## Backward Compatibility

- Existing `bookmarks: string[]` state is preserved unchanged
- All existing bookmark store/action APIs remain intact
- Folders are optional – users who don't create folders see no change in behavior
- The persist middleware storage key (`signal-bookmarks`) remains the same; existing user data is extended with an empty `folders` array


Closes #343 