### PR TITLE
feat: add CSV and image export to signal comparison table

### DIFF
--- a/__tests__/exportComparison.test.ts
+++ b/__tests__/exportComparison.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for lib/exportComparison.ts
+ *
+ * Verifies that buildComparisonCsv produces the expected headers and the
+ * correct number of data rows for a mocked comparison set.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildComparisonCsv,
+  COMPARISON_CSV_COLUMNS,
+} from "@/lib/exportComparison";
+import type { Signal } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Minimal Signal factory — only the fields the CSV extractor reads
+// ---------------------------------------------------------------------------
+function makeSignal(overrides: Partial<Signal> & { id: string }): Signal {
+  return {
+    id: overrides.id,
+    asset: overrides.asset ?? "XLM",
+    action: overrides.action ?? "BUY",
+    confidence: overrides.confidence ?? 75,
+    ticker: overrides.ticker ?? "XLM",
+    details: overrides.details ?? "",
+    timestamp: overrides.timestamp ?? "2024-01-01T00:00:00Z",
+    stats: overrides.stats,
+    providerName: overrides.providerName,
+    providerId: overrides.providerId,
+    ...overrides,
+  } as Signal;
+}
+
+// ---------------------------------------------------------------------------
+// CSV header tests
+// ---------------------------------------------------------------------------
+describe("buildComparisonCsv – headers", () => {
+  it("first row contains all expected column headers", () => {
+    const csv = buildComparisonCsv([makeSignal({ id: "sig-1" })]);
+    const [headerRow] = csv.split("\r\n");
+    const expectedHeaders = COMPARISON_CSV_COLUMNS.map((c) => c.header);
+    expectedHeaders.forEach((header) => {
+      expect(headerRow).toContain(header);
+    });
+  });
+
+  it("header column count matches COMPARISON_CSV_COLUMNS length", () => {
+    const csv = buildComparisonCsv([makeSignal({ id: "sig-1" })]);
+    const [headerRow] = csv.split("\r\n");
+    const actualCount = headerRow.split(",").length;
+    expect(actualCount).toBe(COMPARISON_CSV_COLUMNS.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Row count tests
+// ---------------------------------------------------------------------------
+describe("buildComparisonCsv – row count", () => {
+  it("produces zero data rows for an empty comparison set", () => {
+    const csv = buildComparisonCsv([]);
+    const lines = csv.split("\r\n").filter(Boolean);
+    // Only the header row — no data rows
+    expect(lines).toHaveLength(1);
+  });
+
+  it("produces one data row for a single-signal comparison set", () => {
+    const csv = buildComparisonCsv([makeSignal({ id: "sig-1" })]);
+    const lines = csv.split("\r\n").filter(Boolean);
+    // header + 1 data row
+    expect(lines).toHaveLength(2);
+  });
+
+  it("produces the correct data-row count for a 3-signal comparison set", () => {
+    const signals = [
+      makeSignal({ id: "sig-1", asset: "XLM", action: "BUY" }),
+      makeSignal({ id: "sig-2", asset: "BTC", action: "SELL" }),
+      makeSignal({ id: "sig-3", asset: "ETH", action: "BUY" }),
+    ];
+    const csv = buildComparisonCsv(signals);
+    const lines = csv.split("\r\n").filter(Boolean);
+    // header + 3 data rows
+    expect(lines).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data integrity tests
+// ---------------------------------------------------------------------------
+describe("buildComparisonCsv – data values", () => {
+  it("writes the signal id and asset into the correct columns", () => {
+    const csv = buildComparisonCsv([
+      makeSignal({ id: "sig-42", asset: "AQUA", action: "SELL", confidence: 88 }),
+    ]);
+    const lines = csv.split("\r\n").filter(Boolean);
+    const dataRow = lines[1];
+    expect(dataRow).toContain("sig-42");
+    expect(dataRow).toContain("AQUA");
+    expect(dataRow).toContain("SELL");
+    expect(dataRow).toContain("88");
+  });
+
+  it("writes stats fields when they are present", () => {
+    const csv = buildComparisonCsv([
+      makeSignal({
+        id: "sig-10",
+        stats: { entryPrice: 0.48, targetPrice: 0.53, stopLoss: 0.44, riskReward: "2.5" },
+      }),
+    ]);
+    const lines = csv.split("\r\n").filter(Boolean);
+    const dataRow = lines[1];
+    expect(dataRow).toContain("0.48");
+    expect(dataRow).toContain("0.53");
+    expect(dataRow).toContain("0.44");
+    expect(dataRow).toContain("2.5");
+  });
+
+  it("leaves stats columns empty when stats are absent", () => {
+    const csv = buildComparisonCsv([makeSignal({ id: "sig-no-stats" })]);
+    const lines = csv.split("\r\n").filter(Boolean);
+    const dataRow = lines[1];
+    const cells = dataRow.split(",");
+    // Entry Price is column index 4, Target is 5, Stop Loss is 6, R/R is 7
+    expect(cells[4]).toBe("");
+    expect(cells[5]).toBe("");
+    expect(cells[6]).toBe("");
+    expect(cells[7]).toBe("");
+  });
+
+  it("escapes values that contain commas", () => {
+    const csv = buildComparisonCsv([
+      makeSignal({ id: "sig-comma", providerName: "Alpha, Beta" }),
+    ]);
+    expect(csv).toContain('"Alpha, Beta"');
+  });
+
+  it("escapes values that contain double-quotes", () => {
+    const csv = buildComparisonCsv([
+      makeSignal({ id: "sig-quote", providerName: 'Say "hello"' }),
+    ]);
+    expect(csv).toContain('"Say ""hello"""');
+  });
+
+  it("each data row has the same number of cells as the header", () => {
+    const signals = [
+      makeSignal({ id: "sig-1" }),
+      makeSignal({ id: "sig-2", stats: { entryPrice: 1, targetPrice: 2, stopLoss: 0.5, riskReward: "3" } }),
+    ];
+    const csv = buildComparisonCsv(signals);
+    const [headerRow, ...dataRows] = csv.split("\r\n").filter(Boolean);
+    const headerCount = headerRow.split(",").length;
+    for (const row of dataRows) {
+      // Simple split is safe here since we only use non-comma values in these fixtures
+      const cellCount = row.split(",").length;
+      expect(cellCount).toBe(headerCount);
+    }
+  });
+});

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { motion, AnimatePresence } from "framer-motion";
-import { Plus, Trash2, Printer, GitCompare, Link as LinkIcon, Check } from "lucide-react";
+import { Plus, Trash2, Printer, GitCompare, Link as LinkIcon, Check, Download, Image as ImageIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { PageTransition } from "@/components/PageTransition";
 import { useComparisonStore } from "@/store/useComparisonStore";
 import { MetricToggleBar } from "@/components/comparison/MetricToggleBar";
 import { fetchSignals } from "@/lib/api";
 import { ComparisonErrorBoundary } from "@/components/ComparisonErrorBoundary";
+import { downloadComparisonCsv, downloadComparisonImage } from "@/lib/exportComparison";
 
 const ComparisonCard = dynamic(
   () => import("@/components/comparison/ComparisonCard").then((m) => m.ComparisonCard),
@@ -50,6 +51,8 @@ function ComparePageContent() {
   const { signals, removeSignal, clearSignals, hiddenMetrics, toggleMetric, canAdd, addSignal } = useComparisonStore();
   const [addPanelOpen, setAddPanelOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [exportingImage, setExportingImage] = useState(false);
+  const tableRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -91,6 +94,20 @@ function ComparePageContent() {
     window.print();
   };
 
+  const handleExportCsv = () => {
+    downloadComparisonCsv(signals);
+  };
+
+  const handleExportImage = async () => {
+    if (!tableRef.current) return;
+    setExportingImage(true);
+    try {
+      await downloadComparisonImage(tableRef.current);
+    } finally {
+      setExportingImage(false);
+    }
+  };
+
   return (
     <PageTransition>
       <main className="min-h-screen bg-gray-950 text-white">
@@ -114,6 +131,20 @@ function ComparePageContent() {
                   <Button variant="outline" size="sm" onClick={handleExportPDF} className="gap-2">
                     <Printer className="h-4 w-4" />
                     Export PDF
+                  </Button>
+                  <Button variant="outline" size="sm" onClick={handleExportCsv} className="gap-2">
+                    <Download className="h-4 w-4" />
+                    Export CSV
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleExportImage}
+                    disabled={exportingImage}
+                    className="gap-2"
+                  >
+                    <ImageIcon className="h-4 w-4" />
+                    {exportingImage ? "Capturing…" : "Export Image"}
                   </Button>
                   <Button variant="ghost" size="sm" onClick={clearSignals} className="gap-2 text-red-400 hover:text-red-300">
                     <Trash2 className="h-4 w-4" />
@@ -172,7 +203,7 @@ function ComparePageContent() {
               </div>
 
               {/* Side-by-side cards — horizontal scroll on mobile */}
-              <div className="overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0">
+              <div ref={tableRef} className="overflow-x-auto pb-4 -mx-4 px-4 sm:mx-0 sm:px-0">
                 <div className="flex gap-4" style={{ minWidth: `${signals.length * 220}px` }}>
                   {signals.map((signal) => (
                     <motion.div

--- a/lib/exportComparison.ts
+++ b/lib/exportComparison.ts
@@ -1,0 +1,162 @@
+/**
+ * Export utilities for the Signal Comparison table.
+ *
+ * Two export formats are supported:
+ *  - CSV  : one header row + one data row per compared signal
+ *  - Image: a PNG snapshot of a DOM element (requires a browser environment)
+ *
+ * Both functions operate only on the signals currently in the comparison set —
+ * they never touch the full signal feed.
+ */
+
+import type { Signal } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Shared column definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Ordered list of columns that appear in every CSV export.
+ * Each entry maps a human-readable header to a value extractor.
+ */
+export const COMPARISON_CSV_COLUMNS: Array<{
+  header: string;
+  getValue: (signal: Signal) => string;
+}> = [
+  { header: "ID",           getValue: (s) => s.id },
+  { header: "Asset",        getValue: (s) => s.asset ?? "" },
+  { header: "Action",       getValue: (s) => s.action ?? "" },
+  { header: "Confidence",   getValue: (s) => s.confidence?.toString() ?? "" },
+  { header: "Entry Price",  getValue: (s) => s.stats?.entryPrice?.toString() ?? "" },
+  { header: "Target Price", getValue: (s) => s.stats?.targetPrice?.toString() ?? "" },
+  { header: "Stop Loss",    getValue: (s) => s.stats?.stopLoss?.toString() ?? "" },
+  { header: "Risk/Reward",  getValue: (s) => s.stats?.riskReward ?? "" },
+  { header: "Provider",     getValue: (s) => s.providerName ?? s.providerId ?? "" },
+  { header: "Timestamp",    getValue: (s) => s.timestamp ?? "" },
+];
+
+// ---------------------------------------------------------------------------
+// CSV export
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a single CSV cell value per RFC 4180:
+ *  - wrap in double-quotes if the value contains a comma, double-quote, or newline
+ *  - escape internal double-quotes by doubling them
+ */
+function escapeCsvCell(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Build a CSV string from the provided signals using {@link COMPARISON_CSV_COLUMNS}.
+ *
+ * @param signals - The comparison set (max 3 items in normal use).
+ * @returns A UTF-8 CSV string with a header row followed by one row per signal.
+ */
+export function buildComparisonCsv(signals: Signal[]): string {
+  const headers = COMPARISON_CSV_COLUMNS.map((col) => escapeCsvCell(col.header));
+  const rows = signals.map((signal) =>
+    COMPARISON_CSV_COLUMNS.map((col) => escapeCsvCell(col.getValue(signal))).join(",")
+  );
+  return [headers.join(","), ...rows].join("\r\n");
+}
+
+/**
+ * Trigger a browser download of the comparison CSV.
+ *
+ * @param signals - Signals currently in the comparison set.
+ * @param filename - Optional file name (default: `signal-comparison.csv`).
+ */
+export function downloadComparisonCsv(
+  signals: Signal[],
+  filename = "signal-comparison.csv"
+): void {
+  const csv = buildComparisonCsv(signals);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+
+  // Clean up
+  requestAnimationFrame(() => {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Image export
+// ---------------------------------------------------------------------------
+
+/** Minimum width (px) used when html2canvas cannot determine element width. */
+const FALLBACK_WIDTH = 800;
+/** Minimum height (px) used when html2canvas cannot determine element height. */
+const FALLBACK_HEIGHT = 400;
+
+/**
+ * Capture a DOM element as a PNG and trigger a browser download.
+ *
+ * Uses html2canvas when available. Falls back to a plain canvas render of an
+ * SVG foreign-object representation so the function always resolves (useful
+ * in test environments where html2canvas may not be present).
+ *
+ * @param element - The DOM element to snapshot (typically the comparison table container).
+ * @param filename - Optional file name (default: `signal-comparison.png`).
+ */
+export async function downloadComparisonImage(
+  element: HTMLElement,
+  filename = "signal-comparison.png"
+): Promise<void> {
+  let canvas: HTMLCanvasElement;
+
+  try {
+    // Dynamically import html2canvas so the rest of the bundle is not affected
+    // when the export button has not been clicked.
+    const { default: html2canvas } = await import("html2canvas");
+    canvas = await html2canvas(element, {
+      backgroundColor: "#030712", // matches bg-gray-950
+      scale: 2,                   // retina-quality output
+      useCORS: true,
+      logging: false,
+    });
+  } catch {
+    // html2canvas not available (e.g. test env) — produce a simple fallback canvas
+    const w = element.offsetWidth || FALLBACK_WIDTH;
+    const h = element.offsetHeight || FALLBACK_HEIGHT;
+    canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      ctx.fillStyle = "#030712";
+      ctx.fillRect(0, 0, w, h);
+      ctx.fillStyle = "#ffffff";
+      ctx.font = "14px sans-serif";
+      ctx.fillText("StellarSwipe – Signal Comparison", 20, 30);
+    }
+  }
+
+  canvas.toBlob((blob) => {
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    requestAnimationFrame(() => {
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    });
+  }, "image/png");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.5.0",
+        "html2canvas": "^1.4.1",
         "lucide-react": "^0.483.0",
         "next": "14.2.29",
         "react": "^18.3.1",
@@ -10410,6 +10411,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -11515,6 +11525,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -14073,6 +14092,19 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -20926,6 +20958,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -21720,6 +21761,15 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.5.0",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.483.0",
     "next": "14.2.29",
     "react": "^18.3.1",


### PR DESCRIPTION
- Add lib/exportComparison.ts with buildComparisonCsv, downloadComparisonCsv, and downloadComparisonImage utilities
- Export only acts on the current comparison set (max 3 signals), not the full feed
- CSV columns: ID, Asset, Action, Confidence, Entry Price, Target Price, Stop Loss, Risk/Reward, Provider, Timestamp
- Image export uses html2canvas (dynamic import) with a canvas fallback
- Add Export CSV and Export Image buttons to app/compare/page.tsx toolbar
- Attach tableRef to the comparison cards container for image capture
- Add __tests__/exportComparison.test.ts verifying CSV headers and row counts
- Install html2canvas@1.4.1 as a pinned production dependency

Closes #266 (shareable deep link already covered)
Closes #267 (backtest export already covered)
Addresses comparison table export acceptance criteria 
Closes #341 