### PR TITLE
feat: add SettingsBreadcrumb component for nested settings navigation

### DIFF
--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -13,6 +13,7 @@ import { auditReports } from "@/content/audits";
 import { AnalyticsConsentToggle } from "@/components/AnalyticsConsentToggle";
 import { NotificationPermissionButton } from "@/components/NotificationPermissionButton";
 import { useNotificationPreference } from "@/hooks/useNotificationPreference";
+import { SettingsBreadcrumb } from "@/components/SettingsBreadcrumb";
 
 export default function SecuritySettingsPage() {
   const [twoFactorEnabled, setTwoFactorEnabled] = useState(false);
@@ -27,6 +28,7 @@ export default function SecuritySettingsPage() {
   return (
     <main className="min-h-screen bg-background px-4 py-6 sm:px-6 sm:py-8 lg:px-8 text-foreground">
       <div className="mx-auto w-full max-w-2xl space-y-6">
+        <SettingsBreadcrumb />
         {/* Page header */}
         <div className="flex items-center gap-2">
           <Shield size={20} className="text-blue-400" aria-hidden="true" />

--- a/components/SettingsBreadcrumb.tsx
+++ b/components/SettingsBreadcrumb.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronRight } from "lucide-react";
+import { BREADCRUMB_ROUTES, type BreadcrumbSegment } from "@/lib/breadcrumbRoutes";
+
+interface SettingsBreadcrumbProps {
+  /** Override segments instead of deriving from the current pathname. */
+  segments?: BreadcrumbSegment[];
+}
+
+export function SettingsBreadcrumb({ segments: segmentsProp }: SettingsBreadcrumbProps) {
+  const pathname = usePathname();
+  const segments = segmentsProp ?? BREADCRUMB_ROUTES[pathname];
+
+  if (!segments || segments.length < 2) return null;
+
+  return (
+    <nav aria-label="Breadcrumb" className="mb-4">
+      <ol className="flex flex-wrap items-center gap-1 text-sm text-foreground-muted">
+        {segments.map((seg, i) => {
+          const isCurrent = i === segments.length - 1;
+          return (
+            <li key={seg.href} className="flex items-center gap-1">
+              {i > 0 && (
+                <ChevronRight
+                  size={13}
+                  className="shrink-0 text-foreground-muted/50"
+                  aria-hidden="true"
+                />
+              )}
+              {isCurrent ? (
+                <span aria-current="page" className="font-medium text-foreground">
+                  {seg.label}
+                </span>
+              ) : (
+                <Link
+                  href={seg.href}
+                  className="hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded-sm"
+                >
+                  {seg.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/components/__tests__/SettingsBreadcrumb.test.tsx
+++ b/components/__tests__/SettingsBreadcrumb.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { SettingsBreadcrumb } from "@/components/SettingsBreadcrumb";
+
+// Mock next/navigation
+let mockPathname = "/security";
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+// Mock next/link so hrefs are accessible in jsdom
+jest.mock("next/link", () => {
+  const Link = ({ href, children, ...rest }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+    <a href={href} {...rest}>{children}</a>
+  );
+  Link.displayName = "Link";
+  return Link;
+});
+
+describe("SettingsBreadcrumb", () => {
+  describe("route-derived breadcrumbs", () => {
+    it("renders the correct trail for /security (2-segment path)", () => {
+      mockPathname = "/security";
+      render(<SettingsBreadcrumb />);
+
+      const nav = screen.getByRole("navigation", { name: "Breadcrumb" });
+      expect(nav).toBeTruthy();
+
+      // 'Settings' should be a link
+      const settingsLink = screen.getByRole("link", { name: "Settings" });
+      expect(settingsLink.getAttribute("href")).toBe("/settings");
+
+      // 'Security' is the current page — not a link
+      const currentPage = screen.getByText("Security");
+      expect(currentPage.getAttribute("aria-current")).toBe("page");
+      expect(screen.queryByRole("link", { name: "Security" })).toBeNull();
+    });
+
+    it("renders the correct trail for /security/active-sessions (3-segment path)", () => {
+      mockPathname = "/security/active-sessions";
+      render(<SettingsBreadcrumb />);
+
+      // Two links: Settings and Security
+      const settingsLink = screen.getByRole("link", { name: "Settings" });
+      expect(settingsLink.getAttribute("href")).toBe("/settings");
+
+      const securityLink = screen.getByRole("link", { name: "Security" });
+      expect(securityLink.getAttribute("href")).toBe("/security");
+
+      // 'Active Sessions' is the current page
+      const currentPage = screen.getByText("Active Sessions");
+      expect(currentPage.getAttribute("aria-current")).toBe("page");
+    });
+  });
+
+  describe("custom segments prop", () => {
+    it("renders segments passed via prop instead of route lookup", () => {
+      mockPathname = "/some/unregistered/route";
+      render(
+        <SettingsBreadcrumb
+          segments={[
+            { label: "Settings", href: "/settings" },
+            { label: "Profile", href: "/settings/profile" },
+          ]}
+        />
+      );
+
+      expect(screen.getByRole("link", { name: "Settings" })).toBeTruthy();
+      const current = screen.getByText("Profile");
+      expect(current.getAttribute("aria-current")).toBe("page");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("renders nothing when the pathname is not in the route map", () => {
+      mockPathname = "/unknown-page";
+      const { container } = render(<SettingsBreadcrumb />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing for a single-segment trail", () => {
+      const { container } = render(
+        <SettingsBreadcrumb segments={[{ label: "Settings", href: "/settings" }]} />
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("uses an ordered list with correct ARIA structure", () => {
+      mockPathname = "/security";
+      render(<SettingsBreadcrumb />);
+      const list = screen.getByRole("list");
+      expect(list.tagName).toBe("OL");
+      const items = screen.getAllByRole("listitem");
+      expect(items).toHaveLength(2);
+    });
+  });
+});

--- a/lib/breadcrumbRoutes.ts
+++ b/lib/breadcrumbRoutes.ts
@@ -1,0 +1,36 @@
+export interface BreadcrumbSegment {
+  label: string;
+  href: string;
+}
+
+/**
+ * Route metadata for breadcrumb navigation in nested settings pages.
+ * Key: pathname, Value: ordered list of segments (root → current).
+ */
+export const BREADCRUMB_ROUTES: Record<string, BreadcrumbSegment[]> = {
+  "/security": [
+    { label: "Settings", href: "/settings" },
+    { label: "Security", href: "/security" },
+  ],
+  "/security/active-sessions": [
+    { label: "Settings", href: "/settings" },
+    { label: "Security", href: "/security" },
+    { label: "Active Sessions", href: "/security/active-sessions" },
+  ],
+  "/settings/notifications": [
+    { label: "Settings", href: "/settings" },
+    { label: "Notifications", href: "/settings/notifications" },
+  ],
+  "/settings/webhooks": [
+    { label: "Settings", href: "/settings" },
+    { label: "Webhooks", href: "/settings/webhooks" },
+  ],
+  "/settings/profile": [
+    { label: "Settings", href: "/settings" },
+    { label: "Profile", href: "/settings/profile" },
+  ],
+  "/settings/billing": [
+    { label: "Settings", href: "/settings" },
+    { label: "Billing", href: "/settings/billing" },
+  ],
+};

--- a/stories/SettingsBreadcrumb.stories.tsx
+++ b/stories/SettingsBreadcrumb.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SettingsBreadcrumb } from "@/components/SettingsBreadcrumb";
+
+const meta: Meta<typeof SettingsBreadcrumb> = {
+  title: "Navigation/SettingsBreadcrumb",
+  component: SettingsBreadcrumb,
+  tags: ["autodocs"],
+  parameters: {
+    // next/navigation is mocked by the Storybook Next.js framework
+    nextjs: { appDirectory: true },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingsBreadcrumb>;
+
+/** Two-level: Settings → Security */
+export const TwoLevels: Story = {
+  args: {
+    segments: [
+      { label: "Settings", href: "/settings" },
+      { label: "Security", href: "/security" },
+    ],
+  },
+};
+
+/** Three-level: Settings → Security → Active Sessions */
+export const ThreeLevels: Story = {
+  args: {
+    segments: [
+      { label: "Settings", href: "/settings" },
+      { label: "Security", href: "/security" },
+      { label: "Active Sessions", href: "/security/active-sessions" },
+    ],
+  },
+};
+
+/** Four-level: deep nesting example */
+export const FourLevels: Story = {
+  args: {
+    segments: [
+      { label: "Settings", href: "/settings" },
+      { label: "Billing", href: "/settings/billing" },
+      { label: "Invoices", href: "/settings/billing/invoices" },
+      { label: "Invoice #1042", href: "/settings/billing/invoices/1042" },
+    ],
+  },
+};
+
+/** Renders nothing — single segment is below the minimum threshold */
+export const SingleSegment: Story = {
+  args: {
+    segments: [{ label: "Settings", href: "/settings" }],
+  },
+};


### PR DESCRIPTION
- Add lib/breadcrumbRoutes.ts with BreadcrumbSegment type and BREADCRUMB_ROUTES map
- Add components/SettingsBreadcrumb.tsx: reads pathname, renders nav/ol with aria-label=Breadcrumb, current page gets aria-current=page
- Wire SettingsBreadcrumb into app/security/page.tsx
- Add unit tests (6 passing): route-derived trails for /security and /security/active-sessions, custom segments prop, unknown pathname, single-segment, ARIA structure
- Add Storybook stories: TwoLevels, ThreeLevels, FourLevels, SingleSegment

Closes #410