### PR TITLE
feat: add mark all as read bulk action to notification center

### DIFF
--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -2,33 +2,33 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-
-export interface Notification {
-  id: string;
-  title: string;
-  message: string;
-  read: boolean;
-}
-
-const SAMPLE_NOTIFICATIONS: Notification[] = [
-  { id: "1", title: "XLM/USDC", message: "New BUY signal — high confidence", read: false },
-  { id: "2", title: "BTC/XLM", message: "New SELL signal — momentum reversal", read: false },
-];
+import { useNotificationStore } from "@/store/useNotificationStore";
 
 export function NotificationBell() {
-  const [notifications, setNotifications] = useState<Notification[]>(SAMPLE_NOTIFICATIONS);
+  const notifications = useNotificationStore((s) => s.notifications);
+  const isMarkingAllRead = useNotificationStore((s) => s.isMarkingAllRead);
+  const markAllAsRead = useNotificationStore((s) => s.markAllAsRead);
+  const clearAll = useNotificationStore((s) => s.clearAll);
+  const unreadCount = useNotificationStore((s) => s.unreadCount());
+
   const [open, setOpen] = useState(false);
 
-  const unreadCount = notifications.filter((n) => !n.read).length;
+  const hasUnread = unreadCount > 0;
 
-  const clearAll = () => setNotifications([]);
+  const handleMarkAllAsRead = () => {
+    if (!hasUnread || isMarkingAllRead) return;
+    // No backend yet — purely local optimistic update.
+    markAllAsRead().catch(() => {
+      // rollback already handled inside the store; future error UI can hook here
+    });
+  };
 
   return (
     <div className="relative">
       <button
         aria-label={
-          unreadCount > 0
-            ? `${unreadCount} unread notifications`
+          hasUnread
+            ? `${unreadCount} unread notification${unreadCount === 1 ? "" : "s"}`
             : "Notifications, none unread"
         }
         onClick={() => setOpen((v) => !v)}
@@ -50,7 +50,7 @@ export function NotificationBell() {
         </svg>
 
         <AnimatePresence>
-          {unreadCount > 0 && (
+          {hasUnread && (
             <motion.span
               key="badge"
               initial={{ scale: 0 }}
@@ -85,17 +85,32 @@ export function NotificationBell() {
             >
               <div className="flex items-center justify-between px-4 py-2 border-b">
                 <span className="text-sm font-semibold">Notifications</span>
-                {notifications.length > 0 && (
-                  <button
-                    onClick={clearAll}
-                    className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    Clear all
-                  </button>
-                )}
+
+                <div className="flex items-center gap-2">
+                  {/* Mark all as read — visible only when at least one unread exists */}
+                  {hasUnread && (
+                    <button
+                      onClick={handleMarkAllAsRead}
+                      disabled={isMarkingAllRead}
+                      aria-label="Mark all notifications as read"
+                      className="text-xs text-blue-500 hover:text-blue-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    >
+                      {isMarkingAllRead ? "Marking…" : "Mark all as read"}
+                    </button>
+                  )}
+
+                  {notifications.length > 0 && (
+                    <button
+                      onClick={clearAll}
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Clear all
+                    </button>
+                  )}
+                </div>
               </div>
 
-              <ul className="max-h-64 overflow-y-auto divide-y">
+              <ul className="max-h-64 overflow-y-auto divide-y" role="list">
                 {notifications.length === 0 ? (
                   <li className="px-4 py-6 text-center text-sm text-muted-foreground">
                     No notifications
@@ -104,7 +119,10 @@ export function NotificationBell() {
                   notifications.map((n) => (
                     <li key={n.id} className="flex gap-3 px-4 py-3">
                       {!n.read && (
-                        <span className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-red-500" aria-hidden="true" />
+                        <span
+                          className="mt-1.5 h-2 w-2 flex-shrink-0 rounded-full bg-red-500"
+                          aria-hidden="true"
+                        />
                       )}
                       <div className={n.read ? "pl-5" : ""}>
                         <p className="text-sm font-medium">{n.title}</p>

--- a/store/__tests__/useNotificationStore.test.ts
+++ b/store/__tests__/useNotificationStore.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for useNotificationStore
+ *
+ * Covers:
+ *  - initial state and unreadCount selector
+ *  - markAsRead (single notification)
+ *  - markAllAsRead — optimistic update
+ *  - markAllAsRead — rollback on persist failure
+ *  - markAllAsRead — isMarkingAllRead flag lifecycle
+ *  - markAllAsRead is a no-op / safe when already all-read
+ *  - badge count reaches 0 after markAllAsRead
+ *  - category preference toggles are unaffected
+ *  - clearAll
+ *  - setNotifications
+ */
+
+import { useNotificationStore } from "@/store/useNotificationStore";
+
+const INITIAL_NOTIFICATIONS = [
+  { id: "1", title: "XLM/USDC", message: "New BUY signal — high confidence", read: false },
+  { id: "2", title: "BTC/XLM", message: "New SELL signal — momentum reversal", read: false },
+];
+
+/** Reset store state before each test to prevent cross-test pollution. */
+beforeEach(() => {
+  useNotificationStore.setState({
+    notifications: INITIAL_NOTIFICATIONS.map((n) => ({ ...n })),
+    isMarkingAllRead: false,
+  });
+});
+
+describe("useNotificationStore — initial state", () => {
+  it("starts with the seeded notifications", () => {
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications).toHaveLength(2);
+  });
+
+  it("unreadCount returns 2 when both notifications are unread", () => {
+    const { unreadCount } = useNotificationStore.getState();
+    expect(unreadCount()).toBe(2);
+  });
+
+  it("isMarkingAllRead is false initially", () => {
+    expect(useNotificationStore.getState().isMarkingAllRead).toBe(false);
+  });
+});
+
+describe("useNotificationStore — markAsRead (single)", () => {
+  it("marks only the targeted notification as read", () => {
+    useNotificationStore.getState().markAsRead("1");
+    const { notifications, unreadCount } = useNotificationStore.getState();
+    expect(notifications.find((n) => n.id === "1")!.read).toBe(true);
+    expect(notifications.find((n) => n.id === "2")!.read).toBe(false);
+    expect(unreadCount()).toBe(1);
+  });
+
+  it("is idempotent — marking an already-read notification has no effect", () => {
+    useNotificationStore.setState({
+      notifications: [{ id: "1", title: "T", message: "M", read: true }],
+    });
+    useNotificationStore.getState().markAsRead("1");
+    expect(useNotificationStore.getState().notifications[0].read).toBe(true);
+  });
+});
+
+describe("useNotificationStore — markAllAsRead (no persist callback)", () => {
+  it("marks every notification as read", async () => {
+    await useNotificationStore.getState().markAllAsRead();
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications.every((n) => n.read)).toBe(true);
+  });
+
+  it("reduces unreadCount to 0", async () => {
+    await useNotificationStore.getState().markAllAsRead();
+    expect(useNotificationStore.getState().unreadCount()).toBe(0);
+  });
+
+  it("resets isMarkingAllRead to false after completion", async () => {
+    await useNotificationStore.getState().markAllAsRead();
+    expect(useNotificationStore.getState().isMarkingAllRead).toBe(false);
+  });
+
+  it("does not remove any notifications from the list", async () => {
+    await useNotificationStore.getState().markAllAsRead();
+    expect(useNotificationStore.getState().notifications).toHaveLength(2);
+  });
+
+  it("is safe to call when already all-read", async () => {
+    useNotificationStore.setState({
+      notifications: INITIAL_NOTIFICATIONS.map((n) => ({ ...n, read: true })),
+    });
+    await expect(useNotificationStore.getState().markAllAsRead()).resolves.toBeUndefined();
+    expect(useNotificationStore.getState().unreadCount()).toBe(0);
+  });
+});
+
+describe("useNotificationStore — markAllAsRead with persist callback", () => {
+  it("calls the persist callback", async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    await useNotificationStore.getState().markAllAsRead(persist);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps all notifications read when persist succeeds", async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    await useNotificationStore.getState().markAllAsRead(persist);
+    expect(useNotificationStore.getState().notifications.every((n) => n.read)).toBe(true);
+    expect(useNotificationStore.getState().unreadCount()).toBe(0);
+  });
+
+  it("rolls back notifications when persist rejects", async () => {
+    const persist = jest.fn().mockRejectedValue(new Error("network error"));
+    await expect(
+      useNotificationStore.getState().markAllAsRead(persist)
+    ).rejects.toThrow("network error");
+
+    const { notifications, unreadCount } = useNotificationStore.getState();
+    // Notifications are restored to pre-call state
+    expect(notifications.every((n) => !n.read)).toBe(true);
+    expect(unreadCount()).toBe(2);
+  });
+
+  it("resets isMarkingAllRead to false after rollback", async () => {
+    const persist = jest.fn().mockRejectedValue(new Error("fail"));
+    await useNotificationStore.getState().markAllAsRead(persist).catch(() => {});
+    expect(useNotificationStore.getState().isMarkingAllRead).toBe(false);
+  });
+});
+
+describe("useNotificationStore — badge state", () => {
+  it("badge count equals number of unread notifications", () => {
+    useNotificationStore.setState({
+      notifications: [
+        { id: "1", title: "A", message: "M", read: false },
+        { id: "2", title: "B", message: "M", read: true },
+        { id: "3", title: "C", message: "M", read: false },
+      ],
+    });
+    expect(useNotificationStore.getState().unreadCount()).toBe(2);
+  });
+
+  it("badge count drops to 0 immediately after markAllAsRead (optimistic)", async () => {
+    // Capture count right after the synchronous optimistic update.
+    // Because markAllAsRead is async but the optimistic set() is synchronous,
+    // we start the call and check state before it resolves.
+    const slowPersist = () => new Promise<void>((resolve) => setTimeout(resolve, 50));
+    const promise = useNotificationStore.getState().markAllAsRead(slowPersist);
+
+    // The optimistic update is synchronous — unreadCount is already 0.
+    expect(useNotificationStore.getState().unreadCount()).toBe(0);
+
+    await promise;
+  });
+});
+
+describe("useNotificationStore — clearAll", () => {
+  it("empties the notification list", () => {
+    useNotificationStore.getState().clearAll();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("unreadCount is 0 after clearAll", () => {
+    useNotificationStore.getState().clearAll();
+    expect(useNotificationStore.getState().unreadCount()).toBe(0);
+  });
+});
+
+describe("useNotificationStore — setNotifications", () => {
+  it("replaces the notification list", () => {
+    const newNotifications = [
+      { id: "99", title: "New", message: "Msg", read: false },
+    ];
+    useNotificationStore.getState().setNotifications(newNotifications);
+    expect(useNotificationStore.getState().notifications).toEqual(newNotifications);
+  });
+
+  it("updates unreadCount after replacement", () => {
+    useNotificationStore.getState().setNotifications([
+      { id: "a", title: "A", message: "M", read: true },
+      { id: "b", title: "B", message: "M", read: false },
+    ]);
+    expect(useNotificationStore.getState().unreadCount()).toBe(1);
+  });
+});
+
+describe("useNotificationStore — notification preferences isolation", () => {
+  it("markAllAsRead does not alter the notification objects beyond the read flag", async () => {
+    await useNotificationStore.getState().markAllAsRead();
+    const { notifications } = useNotificationStore.getState();
+
+    // Titles, messages, and ids must be untouched
+    expect(notifications[0]).toMatchObject({ id: "1", title: "XLM/USDC" });
+    expect(notifications[1]).toMatchObject({ id: "2", title: "BTC/XLM" });
+  });
+});

--- a/store/useNotificationStore.ts
+++ b/store/useNotificationStore.ts
@@ -1,0 +1,86 @@
+import { create } from "zustand";
+
+export interface Notification {
+  id: string;
+  title: string;
+  message: string;
+  read: boolean;
+}
+
+interface NotificationState {
+  notifications: Notification[];
+  /** True while a markAllAsRead API call is in flight. */
+  isMarkingAllRead: boolean;
+  /** Count of notifications with read === false. */
+  unreadCount: () => number;
+  /** Replace the full notification list (e.g. after a fetch). */
+  setNotifications: (notifications: Notification[]) => void;
+  /** Mark a single notification as read. */
+  markAsRead: (id: string) => void;
+  /**
+   * Optimistically mark every unread notification as read.
+   *
+   * Accepts an optional async `persist` callback that mirrors the change to a
+   * backend.  If `persist` throws, the store is rolled back to its pre-call
+   * state and the error is re-thrown so callers can surface it.
+   *
+   * When no `persist` is supplied the update is applied locally only.
+   */
+  markAllAsRead: (persist?: () => Promise<void>) => Promise<void>;
+  /** Remove all notifications from the list. */
+  clearAll: () => void;
+}
+
+export const useNotificationStore = create<NotificationState>()((set, get) => ({
+  notifications: [
+    {
+      id: "1",
+      title: "XLM/USDC",
+      message: "New BUY signal — high confidence",
+      read: false,
+    },
+    {
+      id: "2",
+      title: "BTC/XLM",
+      message: "New SELL signal — momentum reversal",
+      read: false,
+    },
+  ],
+
+  isMarkingAllRead: false,
+
+  unreadCount: () => get().notifications.filter((n) => !n.read).length,
+
+  setNotifications: (notifications) => set({ notifications }),
+
+  markAsRead: (id) =>
+    set((state) => ({
+      notifications: state.notifications.map((n) =>
+        n.id === id ? { ...n, read: true } : n
+      ),
+    })),
+
+  markAllAsRead: async (persist) => {
+    const previous = get().notifications;
+
+    // Optimistic update
+    set({
+      isMarkingAllRead: true,
+      notifications: previous.map((n) => ({ ...n, read: true })),
+    });
+
+    if (persist) {
+      try {
+        await persist();
+      } catch (err) {
+        // Rollback on failure
+        set({ notifications: previous, isMarkingAllRead: false });
+        throw err;
+      }
+    }
+
+    set({ isMarkingAllRead: false });
+  },
+
+  clearAll: () => set({ notifications: [] }),
+}));


### PR DESCRIPTION

  Summary
  
  Adds a "Mark all as read" button to the notification center dropdown, allowing users to clear
  unread status across all notifications in a single action instead of one at a time.
  
  Changes
  
  store/useNotificationStore.ts (new)
  
  - Zustand store that owns the notification list, replacing the local useState in
  NotificationBell
  - markAllAsRead(persist?) — applies an optimistic update synchronously, then awaits an optional
  backend persist callback; rolls back to the pre-call snapshot if the callback throws
  - unreadCount() selector drives the badge count and button visibility
  - markAsRead, clearAll, setNotifications for future extensibility
  
  components/NotificationBell.tsx (updated)
  
  - Reads state from useNotificationStore — badge and list are now reactive to the store
  - "Mark all as read" button renders only when unreadCount > 0 (hidden when nothing is unread)
  - Button is disabled while isMarkingAllRead is true to prevent double-submission
  - Badge animates to zero immediately on the optimistic update
  
  store/__tests__/useNotificationStore.test.ts (new)
  
  - 21 unit tests covering: initial state, single markAsRead, markAllAsRead with no callback,
  with a succeeding callback, with a failing callback (rollback), isMarkingAllRead lifecycle,
  badge dropping to 0 synchronously, safety when already all-read, clearAll, setNotifications,
  and preference isolation
  
  What was tested
  
  - All 21 new tests pass (npx jest store/__tests__/useNotificationStore.test.ts)
  - Full suite run confirms zero regressions — no new failures introduced
  
  Acceptance criteria
  
  ┌────────────────────────────────────────────────────────────────────┬────────┐
  │ Criterion                                                          │ Status │
  ├────────────────────────────────────────────────────────────────────┼────────┤
  │ Control visible when ≥ 1 unread notification exists                │ ✅     │
  ├────────────────────────────────────────────────────────────────────┼────────┤
  │ Marks all as read in a single action with optimistic UI + rollback │ ✅     │
  ├────────────────────────────────────────────────────────────────────┼────────┤
  │ Unread badge updates immediately                                   │ ✅     │
  ├────────────────────────────────────────────────────────────────────┼────────┤
  │ Control hidden/disabled when no unread notifications               │ ✅     │
  ├────────────────────────────────────────────────────────────────────┼────────┤
  │ Does not affect notification preference/category toggles           │ ✅     │
  ├────────────────────────────────────────────────────────────────────┼────────┤
  │ Unit tests cover bulk action and badge/list state                  │ ✅     │
  └────────────────────────────────────────────────────────────────────┴────────┘
closes #409