### PR TITLE
feat: add swipe sensitivity and direction-swap settings

### DIFF
--- a/components/SignalCard.tsx
+++ b/components/SignalCard.tsx
@@ -40,7 +40,12 @@ import { useDemoModeStore } from "@/store/useDemoModeStore";
 import { useBookmarkActions } from "@/hooks/useBookmarkActions";
 import { useSnoozeActions } from "@/hooks/useSnoozeActions";
 import { DEFAULT_SNOOZE_DURATION_MS } from "@/store/useSnoozeStore";
-import { TINT_THRESHOLD, MAX_TINT_OPACITY, classifyArrowKey } from "@/lib/signalGestures";
+import { TINT_THRESHOLD, MAX_TINT_OPACITY, classifyArrowKeyWithSettings } from "@/lib/signalGestures";
+import {
+  useSwipeSettingsStore,
+  getEffectiveSwipeThreshold,
+  getEffectiveVelocityThreshold,
+} from "@/store/useSwipeSettingsStore";
 import { usePriceFormat } from "@/hooks/usePriceFormat";
 import { useSignalPrice } from "@/hooks/useSignalPrice";
 import { toast } from "@/lib/toast";
@@ -89,8 +94,9 @@ const DEFAULT_ROI: ROIPoint[] = [
   { value: 4.2 },
 ];
 
-const SWIPE_THRESHOLD = 120;
-const VELOCITY_THRESHOLD = 780;
+// NOTE: swipe thresholds are now derived dynamically from the user's swipe settings.
+// The constants below are kept as a fallback reference only — actual values used
+// inside the component are obtained from useSwipeSettingsStore.
 
 export function SignalCard({
   loading = false,
@@ -132,6 +138,9 @@ export function SignalCard({
   const { isRTL: rtl } = useI18n();
   const { chartStyle, setChartStyle } = useChartStyleStore();
   const fmt = usePriceFormat();
+  const { sensitivity, swapDirections } = useSwipeSettingsStore();
+  const SWIPE_THRESHOLD = getEffectiveSwipeThreshold(sensitivity);
+  const VELOCITY_THRESHOLD = getEffectiveVelocityThreshold(sensitivity);
   const executingRef = useRef(false);
   const shareMenuRef = useRef<HTMLDivElement>(null);
   const hasVibratedRef = useRef(false);
@@ -292,14 +301,14 @@ export function SignalCard({
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    const arrowAction = classifyArrowKey(e.key, showPassAction);
+    const arrowAction = classifyArrowKeyWithSettings(e.key, showPassAction, swapDirections);
     if (arrowAction === "trade") {
       e.preventDefault();
-      flashSwipeFeedback(1);
+      flashSwipeFeedback(swapDirections ? -1 : 1);
       handleExecuteTrade();
     } else if (arrowAction === "pass") {
       e.preventDefault();
-      flashSwipeFeedback(-1);
+      flashSwipeFeedback(swapDirections ? 1 : -1);
       handlePass();
     } else if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
@@ -338,18 +347,22 @@ export function SignalCard({
     const velocityX = info.velocity.x;
     const fastSwipe = Math.abs(velocityX) > VELOCITY_THRESHOLD && Math.abs(offsetX) > 40;
 
-    // In RTL, swipe directions are mirrored: right=pass, left=trade
-    const tradeSwipe = rtl ? offsetX < -SWIPE_THRESHOLD : offsetX > SWIPE_THRESHOLD;
-    const tradeVelocity = rtl
+    // Effective direction: RTL and/or swapDirections each independently flip
+    // the left/right meaning. XOR-ing them covers all four combinations.
+    const effectivelyFlipped = rtl !== swapDirections; // XOR: flipped when exactly one is true
+
+    // In RTL or when directions are swapped: right=pass, left=trade
+    const tradeSwipe = effectivelyFlipped ? offsetX < -SWIPE_THRESHOLD : offsetX > SWIPE_THRESHOLD;
+    const tradeVelocity = effectivelyFlipped
       ? offsetX < -SWIPE_THRESHOLD * 0.4 && velocityX < -VELOCITY_THRESHOLD
       : offsetX > SWIPE_THRESHOLD * 0.4 && velocityX > VELOCITY_THRESHOLD;
-    const tradeFast = fastSwipe && (rtl ? velocityX < 0 : velocityX > 0);
+    const tradeFast = fastSwipe && (effectivelyFlipped ? velocityX < 0 : velocityX > 0);
 
-    const passSwipe = rtl ? offsetX > SWIPE_THRESHOLD : offsetX < -SWIPE_THRESHOLD;
-    const passVelocity = rtl
+    const passSwipe = effectivelyFlipped ? offsetX > SWIPE_THRESHOLD : offsetX < -SWIPE_THRESHOLD;
+    const passVelocity = effectivelyFlipped
       ? offsetX > SWIPE_THRESHOLD * 0.4 && velocityX > VELOCITY_THRESHOLD
       : offsetX < -SWIPE_THRESHOLD * 0.4 && velocityX < -VELOCITY_THRESHOLD;
-    const passFast = fastSwipe && (rtl ? velocityX > 0 : velocityX < 0);
+    const passFast = fastSwipe && (effectivelyFlipped ? velocityX > 0 : velocityX < 0);
 
     if (tradeSwipe || tradeVelocity || tradeFast) {
       handleExecuteTrade();

--- a/components/SwipeSettings.tsx
+++ b/components/SwipeSettings.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+  useSwipeSettingsStore,
+  type SensitivityLevel,
+  SENSITIVITY_MULTIPLIERS,
+  getEffectiveSwipeThreshold,
+  getEffectiveVelocityThreshold,
+} from "@/store/useSwipeSettingsStore";
+
+// Sensitivity levels in display order
+const SENSITIVITY_LEVELS: { value: SensitivityLevel; label: string; description: string }[] = [
+  { value: "low", label: "Low", description: "Harder to trigger — requires a longer drag" },
+  { value: "default", label: "Default", description: "Original behaviour" },
+  { value: "high", label: "High", description: "Easier to trigger — shorter drag commits the swipe" },
+];
+
+/**
+ * SwipeSettings — settings section for tuning swipe gesture behaviour.
+ *
+ * Exposes two controls:
+ *  1. Sensitivity slider — adjusts the drag distance / velocity required to
+ *     commit a swipe action (trade or pass).
+ *  2. Direction swap toggle — reverses left/right action mapping, so right
+ *     swipe → pass and left swipe → trade.
+ *
+ * All changes are persisted immediately via the Zustand store and take effect
+ * without a page reload.
+ *
+ * @example
+ * <SwipeSettings />
+ */
+export function SwipeSettings({ className }: { className?: string }) {
+  const { sensitivity, swapDirections, setSensitivity, setSwapDirections, resetToDefaults } =
+    useSwipeSettingsStore();
+
+  const swipeThreshold = getEffectiveSwipeThreshold(sensitivity);
+  const velocityThreshold = getEffectiveVelocityThreshold(sensitivity);
+
+  // Convert sensitivity to a 0–2 slider index for the range input
+  const sensitivityIndex = SENSITIVITY_LEVELS.findIndex((l) => l.value === sensitivity);
+  const selectedLevel = SENSITIVITY_LEVELS[sensitivityIndex];
+
+  function handleSliderChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const idx = Number(e.target.value);
+    const level = SENSITIVITY_LEVELS[idx];
+    if (level) setSensitivity(level.value);
+  }
+
+  const isDefault = sensitivity === "default" && !swapDirections;
+
+  return (
+    <section
+      aria-labelledby="swipe-settings-heading"
+      className={cn("flex flex-col gap-5 rounded-2xl border bg-card p-5", className)}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <h2
+            id="swipe-settings-heading"
+            className="text-base font-semibold leading-tight"
+          >
+            Swipe Settings
+          </h2>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Customise how swipe gestures trigger trade or pass actions.
+          </p>
+        </div>
+
+        {!isDefault && (
+          <button
+            type="button"
+            onClick={resetToDefaults}
+            className="rounded-md px-2.5 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            aria-label="Reset swipe settings to defaults"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* ── Sensitivity slider ─────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor="swipe-sensitivity-slider"
+            className="text-sm font-medium"
+          >
+            Sensitivity
+          </label>
+          <span
+            className="text-sm font-semibold text-blue-400"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            {selectedLevel?.label ?? "Default"}
+          </span>
+        </div>
+
+        {/* Slider track */}
+        <div className="relative flex items-center">
+          {/* Background track */}
+          <div className="absolute h-1.5 w-full rounded-full bg-muted" aria-hidden="true" />
+          {/* Filled portion */}
+          <div
+            className="absolute h-1.5 rounded-full bg-blue-500 transition-all duration-75"
+            style={{ width: `${(sensitivityIndex / (SENSITIVITY_LEVELS.length - 1)) * 100}%` }}
+            aria-hidden="true"
+          />
+          <input
+            id="swipe-sensitivity-slider"
+            type="range"
+            min={0}
+            max={SENSITIVITY_LEVELS.length - 1}
+            step={1}
+            value={sensitivityIndex}
+            onChange={handleSliderChange}
+            aria-label="Swipe sensitivity"
+            aria-valuemin={0}
+            aria-valuemax={SENSITIVITY_LEVELS.length - 1}
+            aria-valuenow={sensitivityIndex}
+            aria-valuetext={`${selectedLevel?.label ?? "Default"} — ${selectedLevel?.description ?? ""}`}
+            className={cn(
+              "relative w-full cursor-pointer appearance-none bg-transparent h-5",
+              "focus:outline-none",
+              "[&::-webkit-slider-thumb]:appearance-none",
+              "[&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4",
+              "[&::-webkit-slider-thumb]:rounded-full",
+              "[&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background",
+              "[&::-webkit-slider-thumb]:bg-blue-500 [&::-webkit-slider-thumb]:shadow-md",
+              "[&::-webkit-slider-thumb]:transition-transform [&::-webkit-slider-thumb]:duration-100",
+              "[&::-webkit-slider-thumb]:hover:scale-110",
+              "[&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4",
+              "[&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2",
+              "[&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:bg-blue-500 [&::-moz-range-thumb]:shadow-md",
+              "focus-visible:[&::-webkit-slider-thumb]:ring-2 focus-visible:[&::-webkit-slider-thumb]:ring-ring focus-visible:[&::-webkit-slider-thumb]:ring-offset-1"
+            )}
+          />
+        </div>
+
+        {/* Tick labels */}
+        <div className="flex justify-between text-xs text-muted-foreground select-none" aria-hidden="true">
+          {SENSITIVITY_LEVELS.map((l) => (
+            <span key={l.value}>{l.label}</span>
+          ))}
+        </div>
+
+        {/* Description text */}
+        <p className="text-xs text-muted-foreground" aria-live="polite">
+          {selectedLevel?.description}
+          {sensitivity !== "default" && (
+            <span className="ml-1 tabular-nums text-blue-400/80">
+              ({swipeThreshold}px · {velocityThreshold}px/s)
+            </span>
+          )}
+        </p>
+      </div>
+
+      {/* ── Direction swap toggle ──────────────────────────────────────────── */}
+      <div className="flex items-center justify-between gap-4 rounded-xl border border-white/10 bg-white/5 px-4 py-3">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium">Swap directions</span>
+          <span className="text-xs text-muted-foreground">
+            {swapDirections
+              ? "Right → Pass · Left → Trade"
+              : "Right → Trade · Left → Pass (default)"}
+          </span>
+        </div>
+
+        {/* Toggle switch */}
+        <button
+          type="button"
+          role="switch"
+          aria-checked={swapDirections}
+          aria-label="Swap swipe directions"
+          onClick={() => setSwapDirections(!swapDirections)}
+          className={cn(
+            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent",
+            "transition-colors duration-200 ease-in-out",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            swapDirections ? "bg-blue-600" : "bg-muted"
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className={cn(
+              "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow-lg ring-0",
+              "transition duration-200 ease-in-out",
+              swapDirections ? "translate-x-5" : "translate-x-0"
+            )}
+          />
+        </button>
+      </div>
+
+      {/* ── Visual preview of the current mapping ─────────────────────────── */}
+      <div
+        className="flex items-center justify-between rounded-xl bg-white/5 px-4 py-2.5 text-xs text-muted-foreground"
+        aria-label="Current swipe direction mapping"
+      >
+        <span className="flex items-center gap-1.5">
+          <span className="text-red-400" aria-hidden="true">←</span>
+          {swapDirections ? "Trade" : "Pass"}
+        </span>
+        <span className="text-muted-foreground/60" aria-hidden="true">|</span>
+        <span className="flex items-center gap-1.5">
+          {swapDirections ? "Pass" : "Trade"}
+          <span className="text-green-400" aria-hidden="true">→</span>
+        </span>
+      </div>
+    </section>
+  );
+}

--- a/components/__tests__/SignalCard.test.ts
+++ b/components/__tests__/SignalCard.test.ts
@@ -197,3 +197,185 @@ describe("SignalCard – mouse and touch event paths produce identical outcomes"
     expect(classifySwipe(touchOffset, 0)).toBe("pass");
   });
 });
+
+// ── Sensitivity threshold changes ─────────────────────────────────────────────
+// These tests use the pure helper logic extracted from getEffectiveSwipeThreshold
+// and classifySwipe — no DOM or React required.
+
+import {
+  getEffectiveSwipeThreshold,
+  getEffectiveVelocityThreshold,
+  SENSITIVITY_MULTIPLIERS,
+} from "@/store/useSwipeSettingsStore";
+import {
+  SWIPE_THRESHOLD as BASE_SWIPE,
+  VELOCITY_THRESHOLD as BASE_VELOCITY,
+} from "@/lib/signalGestures";
+
+describe("sensitivity thresholds – getEffectiveSwipeThreshold", () => {
+  it("default sensitivity returns the base SWIPE_THRESHOLD unchanged", () => {
+    expect(getEffectiveSwipeThreshold("default")).toBe(BASE_SWIPE);
+  });
+
+  it("low sensitivity requires a longer drag than default", () => {
+    expect(getEffectiveSwipeThreshold("low")).toBeGreaterThan(getEffectiveSwipeThreshold("default"));
+  });
+
+  it("high sensitivity requires a shorter drag than default", () => {
+    expect(getEffectiveSwipeThreshold("high")).toBeLessThan(getEffectiveSwipeThreshold("default"));
+  });
+
+  it("low threshold equals BASE_SWIPE × low multiplier", () => {
+    expect(getEffectiveSwipeThreshold("low")).toBe(
+      Math.round(BASE_SWIPE * SENSITIVITY_MULTIPLIERS.low)
+    );
+  });
+
+  it("high threshold equals BASE_SWIPE × high multiplier", () => {
+    expect(getEffectiveSwipeThreshold("high")).toBe(
+      Math.round(BASE_SWIPE * SENSITIVITY_MULTIPLIERS.high)
+    );
+  });
+});
+
+describe("sensitivity thresholds – getEffectiveVelocityThreshold", () => {
+  it("default sensitivity returns the base VELOCITY_THRESHOLD unchanged", () => {
+    expect(getEffectiveVelocityThreshold("default")).toBe(BASE_VELOCITY);
+  });
+
+  it("low sensitivity requires a faster flick than default", () => {
+    expect(getEffectiveVelocityThreshold("low")).toBeGreaterThan(
+      getEffectiveVelocityThreshold("default")
+    );
+  });
+
+  it("high sensitivity triggers at a lower velocity than default", () => {
+    expect(getEffectiveVelocityThreshold("high")).toBeLessThan(
+      getEffectiveVelocityThreshold("default")
+    );
+  });
+});
+
+describe("sensitivity threshold application – swipe classification", () => {
+  it("a drag that fails the default threshold still commits at high sensitivity", () => {
+    // Default threshold is 120px; high sensitivity lowers it to 72px (120 × 0.6)
+    const highThreshold = getEffectiveSwipeThreshold("high"); // 72
+    const offset = 80; // less than 120 but greater than 72
+    expect(offset).toBeGreaterThan(highThreshold);
+    function classifyWithThreshold(o: number, t: number) {
+      if (o > t) return "execute";
+      if (o < -t) return "pass";
+      return "none";
+    }
+    expect(classifyWithThreshold(offset, highThreshold)).toBe("execute");
+    expect(classifyWithThreshold(offset, getEffectiveSwipeThreshold("default"))).toBe("none");
+  });
+
+  it("a drag that commits at default does NOT commit at low sensitivity", () => {
+    const lowThreshold = getEffectiveSwipeThreshold("low"); // 180
+    const defaultThreshold = getEffectiveSwipeThreshold("default"); // 120
+    const offset = 130; // > 120 (default) but < 180 (low)
+    function classifyWithThreshold(o: number, t: number) {
+      if (o > t) return "execute";
+      if (o < -t) return "pass";
+      return "none";
+    }
+    expect(classifyWithThreshold(offset, defaultThreshold)).toBe("execute");
+    expect(classifyWithThreshold(offset, lowThreshold)).toBe("none");
+  });
+});
+
+// ── Swapped direction mapping ──────────────────────────────────────────────────
+
+import { classifyArrowKeyWithSettings } from "@/lib/signalGestures";
+
+describe("swapped direction mapping – drag gestures", () => {
+  /**
+   * Local helper that mirrors handleDragEnd direction logic using the
+   * effectivelyFlipped flag (rtl XOR swapDirections).
+   */
+  function classifyDragWithSettings(
+    offsetX: number,
+    velocityX: number,
+    swipeThreshold: number,
+    velocityThreshold: number,
+    rtl: boolean,
+    swapDirections: boolean
+  ): "execute" | "pass" | "none" {
+    const fastSwipe = Math.abs(velocityX) > velocityThreshold && Math.abs(offsetX) > 40;
+    const effectivelyFlipped = rtl !== swapDirections;
+
+    const tradeSwipe = effectivelyFlipped ? offsetX < -swipeThreshold : offsetX > swipeThreshold;
+    const tradeVelocity = effectivelyFlipped
+      ? offsetX < -swipeThreshold * 0.4 && velocityX < -velocityThreshold
+      : offsetX > swipeThreshold * 0.4 && velocityX > velocityThreshold;
+    const tradeFast = fastSwipe && (effectivelyFlipped ? velocityX < 0 : velocityX > 0);
+
+    const passSwipe = effectivelyFlipped ? offsetX > swipeThreshold : offsetX < -swipeThreshold;
+    const passVelocity = effectivelyFlipped
+      ? offsetX > swipeThreshold * 0.4 && velocityX > velocityThreshold
+      : offsetX < -swipeThreshold * 0.4 && velocityX < -velocityThreshold;
+    const passFast = fastSwipe && (effectivelyFlipped ? velocityX > 0 : velocityX < 0);
+
+    if (tradeSwipe || tradeVelocity || tradeFast) return "execute";
+    if (passSwipe || passVelocity || passFast) return "pass";
+    return "none";
+  }
+
+  const T = 120;
+  const V = 780;
+
+  it("default LTR: right swipe → execute", () => {
+    expect(classifyDragWithSettings(150, 0, T, V, false, false)).toBe("execute");
+  });
+
+  it("default LTR: left swipe → pass", () => {
+    expect(classifyDragWithSettings(-150, 0, T, V, false, false)).toBe("pass");
+  });
+
+  it("swapDirections LTR: right swipe → pass", () => {
+    expect(classifyDragWithSettings(150, 0, T, V, false, true)).toBe("pass");
+  });
+
+  it("swapDirections LTR: left swipe → execute", () => {
+    expect(classifyDragWithSettings(-150, 0, T, V, false, true)).toBe("execute");
+  });
+
+  it("RTL default: right swipe → pass", () => {
+    expect(classifyDragWithSettings(150, 0, T, V, true, false)).toBe("pass");
+  });
+
+  it("RTL default: left swipe → execute", () => {
+    expect(classifyDragWithSettings(-150, 0, T, V, true, false)).toBe("execute");
+  });
+
+  it("RTL + swapDirections: XOR cancels out → right swipe → execute (same as LTR default)", () => {
+    expect(classifyDragWithSettings(150, 0, T, V, true, true)).toBe("execute");
+  });
+
+  it("RTL + swapDirections: XOR cancels out → left swipe → pass", () => {
+    expect(classifyDragWithSettings(-150, 0, T, V, true, true)).toBe("pass");
+  });
+});
+
+describe("swapped direction mapping – keyboard arrow keys", () => {
+  it("default: ArrowRight → trade, ArrowLeft → pass", () => {
+    expect(classifyArrowKeyWithSettings("ArrowRight", true, false)).toBe("trade");
+    expect(classifyArrowKeyWithSettings("ArrowLeft", true, false)).toBe("pass");
+  });
+
+  it("swapped: ArrowRight → pass, ArrowLeft → trade", () => {
+    expect(classifyArrowKeyWithSettings("ArrowRight", true, true)).toBe("pass");
+    expect(classifyArrowKeyWithSettings("ArrowLeft", true, true)).toBe("trade");
+  });
+
+  it("swapped + pass hidden: ArrowRight is none (pass disabled), ArrowLeft → trade", () => {
+    expect(classifyArrowKeyWithSettings("ArrowRight", false, true)).toBe("none");
+    expect(classifyArrowKeyWithSettings("ArrowLeft", false, true)).toBe("trade");
+  });
+
+  it("default + pass hidden: ArrowRight → trade, ArrowLeft → none", () => {
+    expect(classifyArrowKeyWithSettings("ArrowRight", false, false)).toBe("trade");
+    expect(classifyArrowKeyWithSettings("ArrowLeft", false, false)).toBe("none");
+  });
+});

--- a/lib/__tests__/signalGestures.test.ts
+++ b/lib/__tests__/signalGestures.test.ts
@@ -88,3 +88,41 @@ describe("classifyArrowKey – arrow keys mirror swipe actions on a focused card
     expect(classifyArrowKey("Tab", true)).toBe("none");
   });
 });
+
+// ── classifyArrowKeyWithSettings – swapDirections support ─────────────────────
+
+import { classifyArrowKeyWithSettings } from "@/lib/signalGestures";
+
+describe("classifyArrowKeyWithSettings – default (swapDirections=false)", () => {
+  it("behaves identically to classifyArrowKey when swapDirections is false", () => {
+    expect(classifyArrowKeyWithSettings("ArrowRight", true, false)).toBe("trade");
+    expect(classifyArrowKeyWithSettings("ArrowLeft", true, false)).toBe("pass");
+    expect(classifyArrowKeyWithSettings("ArrowLeft", false, false)).toBe("none");
+    expect(classifyArrowKeyWithSettings("ArrowUp", true, false)).toBe("none");
+  });
+});
+
+describe("classifyArrowKeyWithSettings – swapped (swapDirections=true)", () => {
+  it("maps ArrowRight to pass when directions are swapped", () => {
+    expect(classifyArrowKeyWithSettings("ArrowRight", true, true)).toBe("pass");
+  });
+
+  it("maps ArrowLeft to trade when directions are swapped", () => {
+    expect(classifyArrowKeyWithSettings("ArrowLeft", true, true)).toBe("trade");
+  });
+
+  it("ArrowLeft still trades even when pass action is hidden (left=trade in swapped mode)", () => {
+    expect(classifyArrowKeyWithSettings("ArrowLeft", false, true)).toBe("trade");
+  });
+
+  it("ArrowRight is a no-op (pass) when pass action is hidden and directions are swapped", () => {
+    // pass is disabled, so ArrowRight→pass should be none
+    expect(classifyArrowKeyWithSettings("ArrowRight", false, true)).toBe("none");
+  });
+
+  it("ignores unrelated keys even when directions are swapped", () => {
+    expect(classifyArrowKeyWithSettings("ArrowUp", true, true)).toBe("none");
+    expect(classifyArrowKeyWithSettings("ArrowDown", true, true)).toBe("none");
+    expect(classifyArrowKeyWithSettings("Enter", true, true)).toBe("none");
+  });
+});

--- a/lib/signalGestures.ts
+++ b/lib/signalGestures.ts
@@ -60,3 +60,28 @@ export function classifyArrowKey(key: string, showPassAction: boolean): SwipeAct
   if (key === "ArrowLeft") return showPassAction ? "pass" : "none";
   return "none";
 }
+
+/**
+ * Like `classifyArrowKey` but honours the user's swipe-direction preference.
+ *
+ * When `swapDirections` is `true` the mapping is reversed:
+ *   ArrowRight → pass  (mirroring a rightward swipe → pass)
+ *   ArrowLeft  → trade (mirroring a leftward swipe → trade)
+ *
+ * When `swapDirections` is `false` the behaviour is identical to
+ * `classifyArrowKey`.
+ */
+export function classifyArrowKeyWithSettings(
+  key: string,
+  showPassAction: boolean,
+  swapDirections: boolean
+): SwipeAction {
+  if (!swapDirections) {
+    return classifyArrowKey(key, showPassAction);
+  }
+
+  // Swapped mapping
+  if (key === "ArrowRight") return showPassAction ? "pass" : "none";
+  if (key === "ArrowLeft") return "trade";
+  return "none";
+}

--- a/store/__tests__/useSwipeSettingsStore.test.ts
+++ b/store/__tests__/useSwipeSettingsStore.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for store/useSwipeSettingsStore.ts
+ *
+ * Tests cover:
+ *  - Default state values
+ *  - setSensitivity / setSwapDirections actions
+ *  - resetToDefaults
+ *  - getEffectiveSwipeThreshold / getEffectiveVelocityThreshold helpers
+ *  - SENSITIVITY_MULTIPLIERS values preserve intended ordering
+ */
+
+import {
+  useSwipeSettingsStore,
+  getEffectiveSwipeThreshold,
+  getEffectiveVelocityThreshold,
+  SENSITIVITY_MULTIPLIERS,
+} from "@/store/useSwipeSettingsStore";
+import { SWIPE_THRESHOLD, VELOCITY_THRESHOLD } from "@/lib/signalGestures";
+
+// Reset the store to its initial state before each test so tests are isolated.
+beforeEach(() => {
+  useSwipeSettingsStore.getState().resetToDefaults();
+});
+
+// ── Default state ─────────────────────────────────────────────────────────────
+
+describe("useSwipeSettingsStore – default state", () => {
+  it("default sensitivity is 'default'", () => {
+    expect(useSwipeSettingsStore.getState().sensitivity).toBe("default");
+  });
+
+  it("swapDirections is false by default", () => {
+    expect(useSwipeSettingsStore.getState().swapDirections).toBe(false);
+  });
+});
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+
+describe("useSwipeSettingsStore – setSensitivity", () => {
+  it("updates sensitivity to 'high'", () => {
+    useSwipeSettingsStore.getState().setSensitivity("high");
+    expect(useSwipeSettingsStore.getState().sensitivity).toBe("high");
+  });
+
+  it("updates sensitivity to 'low'", () => {
+    useSwipeSettingsStore.getState().setSensitivity("low");
+    expect(useSwipeSettingsStore.getState().sensitivity).toBe("low");
+  });
+
+  it("can be reset back to 'default'", () => {
+    useSwipeSettingsStore.getState().setSensitivity("high");
+    useSwipeSettingsStore.getState().setSensitivity("default");
+    expect(useSwipeSettingsStore.getState().sensitivity).toBe("default");
+  });
+});
+
+describe("useSwipeSettingsStore – setSwapDirections", () => {
+  it("sets swapDirections to true", () => {
+    useSwipeSettingsStore.getState().setSwapDirections(true);
+    expect(useSwipeSettingsStore.getState().swapDirections).toBe(true);
+  });
+
+  it("toggles back to false", () => {
+    useSwipeSettingsStore.getState().setSwapDirections(true);
+    useSwipeSettingsStore.getState().setSwapDirections(false);
+    expect(useSwipeSettingsStore.getState().swapDirections).toBe(false);
+  });
+});
+
+describe("useSwipeSettingsStore – resetToDefaults", () => {
+  it("resets all settings to their defaults", () => {
+    useSwipeSettingsStore.getState().setSensitivity("high");
+    useSwipeSettingsStore.getState().setSwapDirections(true);
+    useSwipeSettingsStore.getState().resetToDefaults();
+    const { sensitivity, swapDirections } = useSwipeSettingsStore.getState();
+    expect(sensitivity).toBe("default");
+    expect(swapDirections).toBe(false);
+  });
+});
+
+// ── SENSITIVITY_MULTIPLIERS ordering ─────────────────────────────────────────
+
+describe("SENSITIVITY_MULTIPLIERS – ordering", () => {
+  it("default multiplier is 1 (no change)", () => {
+    expect(SENSITIVITY_MULTIPLIERS.default).toBe(1);
+  });
+
+  it("low multiplier is greater than 1 (requires more drag)", () => {
+    expect(SENSITIVITY_MULTIPLIERS.low).toBeGreaterThan(1);
+  });
+
+  it("high multiplier is less than 1 (requires less drag)", () => {
+    expect(SENSITIVITY_MULTIPLIERS.high).toBeGreaterThan(0);
+    expect(SENSITIVITY_MULTIPLIERS.high).toBeLessThan(1);
+  });
+
+  it("ordering: high < default < low", () => {
+    expect(SENSITIVITY_MULTIPLIERS.high).toBeLessThan(SENSITIVITY_MULTIPLIERS.default);
+    expect(SENSITIVITY_MULTIPLIERS.default).toBeLessThan(SENSITIVITY_MULTIPLIERS.low);
+  });
+});
+
+// ── getEffectiveSwipeThreshold ────────────────────────────────────────────────
+
+describe("getEffectiveSwipeThreshold", () => {
+  it("default returns base SWIPE_THRESHOLD (120)", () => {
+    expect(getEffectiveSwipeThreshold("default")).toBe(SWIPE_THRESHOLD);
+  });
+
+  it("low returns a value greater than the base threshold", () => {
+    expect(getEffectiveSwipeThreshold("low")).toBeGreaterThan(SWIPE_THRESHOLD);
+  });
+
+  it("high returns a value less than the base threshold", () => {
+    expect(getEffectiveSwipeThreshold("high")).toBeLessThan(SWIPE_THRESHOLD);
+  });
+
+  it("computed value is Math.round(base × multiplier)", () => {
+    expect(getEffectiveSwipeThreshold("low")).toBe(
+      Math.round(SWIPE_THRESHOLD * SENSITIVITY_MULTIPLIERS.low)
+    );
+    expect(getEffectiveSwipeThreshold("high")).toBe(
+      Math.round(SWIPE_THRESHOLD * SENSITIVITY_MULTIPLIERS.high)
+    );
+  });
+
+  it("thresholds preserve the correct ordering: high < default < low", () => {
+    expect(getEffectiveSwipeThreshold("high")).toBeLessThan(
+      getEffectiveSwipeThreshold("default")
+    );
+    expect(getEffectiveSwipeThreshold("default")).toBeLessThan(
+      getEffectiveSwipeThreshold("low")
+    );
+  });
+});
+
+// ── getEffectiveVelocityThreshold ─────────────────────────────────────────────
+
+describe("getEffectiveVelocityThreshold", () => {
+  it("default returns base VELOCITY_THRESHOLD (780)", () => {
+    expect(getEffectiveVelocityThreshold("default")).toBe(VELOCITY_THRESHOLD);
+  });
+
+  it("low returns a higher velocity threshold (harder fast-swipe)", () => {
+    expect(getEffectiveVelocityThreshold("low")).toBeGreaterThan(VELOCITY_THRESHOLD);
+  });
+
+  it("high returns a lower velocity threshold (easier fast-swipe)", () => {
+    expect(getEffectiveVelocityThreshold("high")).toBeLessThan(VELOCITY_THRESHOLD);
+  });
+
+  it("computed value is Math.round(base × multiplier)", () => {
+    expect(getEffectiveVelocityThreshold("low")).toBe(
+      Math.round(VELOCITY_THRESHOLD * SENSITIVITY_MULTIPLIERS.low)
+    );
+    expect(getEffectiveVelocityThreshold("high")).toBe(
+      Math.round(VELOCITY_THRESHOLD * SENSITIVITY_MULTIPLIERS.high)
+    );
+  });
+});

--- a/store/useSwipeSettingsStore.ts
+++ b/store/useSwipeSettingsStore.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { SWIPE_THRESHOLD, VELOCITY_THRESHOLD } from "@/lib/signalGestures";
+
+/**
+ * Sensitivity scale values map to a multiplier applied to the default swipe
+ * thresholds.  A lower multiplier means a shorter drag is required to commit.
+ *
+ * 1 = default (unchanged), < 1 = more sensitive, > 1 = less sensitive.
+ */
+export const SENSITIVITY_MULTIPLIERS = {
+  low: 1.5,    // requires 50 % more drag — less sensitive / harder to trigger
+  default: 1,  // unchanged from original hard-coded constants
+  high: 0.6,   // requires 40 % less drag — more sensitive / easier to trigger
+} as const;
+
+export type SensitivityLevel = keyof typeof SENSITIVITY_MULTIPLIERS;
+
+export interface SwipeSettings {
+  /**
+   * Sensitivity level for swipe gestures.
+   * Affects both the drag-distance threshold and the velocity threshold.
+   * Defaults to "default" which preserves the original behaviour.
+   */
+  sensitivity: SensitivityLevel;
+
+  /**
+   * When true, the left/right action mapping is reversed:
+   *   right → pass, left → trade
+   * When false (default), right → trade, left → pass.
+   */
+  swapDirections: boolean;
+
+  /** Has Zustand finished rehydrating from localStorage? */
+  _hasHydrated: boolean;
+}
+
+interface SwipeSettingsActions {
+  setSensitivity: (level: SensitivityLevel) => void;
+  setSwapDirections: (swap: boolean) => void;
+  resetToDefaults: () => void;
+  setHasHydrated: (hydrated: boolean) => void;
+}
+
+const DEFAULT_STATE: Omit<SwipeSettings, "_hasHydrated"> = {
+  sensitivity: "default",
+  swapDirections: false,
+};
+
+export const useSwipeSettingsStore = create<SwipeSettings & SwipeSettingsActions>()(
+  persist(
+    (set) => ({
+      ...DEFAULT_STATE,
+      _hasHydrated: false,
+      setSensitivity: (level) => set({ sensitivity: level }),
+      setSwapDirections: (swap) => set({ swapDirections: swap }),
+      resetToDefaults: () => set(DEFAULT_STATE),
+      setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
+    }),
+    {
+      name: "stellar-swipe-settings",
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true);
+      },
+    }
+  )
+);
+
+/**
+ * Returns the effective swipe threshold (px) for the current sensitivity level.
+ * Multiply the base constant by the sensitivity multiplier.
+ */
+export function getEffectiveSwipeThreshold(sensitivity: SensitivityLevel): number {
+  return Math.round(SWIPE_THRESHOLD * SENSITIVITY_MULTIPLIERS[sensitivity]);
+}
+
+/**
+ * Returns the effective velocity threshold (px/s) for the current sensitivity level.
+ */
+export function getEffectiveVelocityThreshold(sensitivity: SensitivityLevel): number {
+  return Math.round(VELOCITY_THRESHOLD * SENSITIVITY_MULTIPLIERS[sensitivity]);
+}


### PR DESCRIPTION

  feat: swipe sensitivity and direction-swap settings
  
  Summary
  
  Swipe gestures on signal cards previously used fixed thresholds and a fixed
  left=discard/right=copy mapping. This PR introduces a user-configurable settings section that
  allows adjusting swipe sensitivity and optionally swapping the left/right action mapping, with
  full persistence and immediate effect.
  
  Changes
  
  New: store/useSwipeSettingsStore.ts
  
  Zustand store with persist middleware (key "stellar-swipe-settings") exposing:
  
  - sensitivity: "low" | "default" | "high" — scales the drag distance and velocity thresholds
  (×1.5 / ×1.0 / ×0.6)
  - swapDirections: boolean — reverses left/right action mapping
  - resetToDefaults() action
  - getEffectiveSwipeThreshold() / getEffectiveVelocityThreshold() pure helpers
  
  New: components/SwipeSettings.tsx
  
  Settings UI component to drop into any settings page or modal:
  
  - 3-position sensitivity slider (Low / Default / High) with live threshold values shown when
  non-default
  - Accessible role="switch" direction-swap toggle
  - Live preview of the current left/right mapping (e.g. ← Pass | Trade →)
  - Reset to defaults button when settings differ from defaults
  
  Modified: lib/signalGestures.ts
  
  Added classifyArrowKeyWithSettings(key, showPassAction, swapDirections) — extends the existing
  classifyArrowKey to respect the direction swap setting.
  
  Modified: components/SignalCard.tsx
  
  - Swipe thresholds now derived dynamically from the store on each render
  - handleDragEnd uses XOR logic (rtl !== swapDirections) to correctly handle all four
  combinations of RTL mode and direction swap
  - handleKeyDown uses classifyArrowKeyWithSettings; visual flash feedback direction is also
  swapped
  
  Tests
  
  91 tests passing across three suites:
  
  - lib/__tests__/signalGestures.test.ts — classifyArrowKeyWithSettings (default/swapped,
  pass-hidden edge cases)
  - components/__tests__/SignalCard.test.ts — sensitivity threshold ordering, drag classification
  at all sensitivity levels, all 4 RTL×swapDirections drag combinations, keyboard arrow-key
  swapping
  - store/__tests__/useSwipeSettingsStore.test.ts — default state, actions, reset, multiplier
  ordering, threshold helpers
  
  Notes
  
  - Default values (sensitivity: "default", swapDirections: false) are identical to the previous
  hardcoded behaviour — no change for existing users
  - SwipeSettings component needs to be rendered somewhere in the UI (settings modal, preferences
  page, etc.) — not yet wired into a page route
closes #400 