### PR TITLE
feat(hooks): add exponential backoff and stale flag to useSignalPrice

### DIFF
--- a/hooks/useSignalPrice.ts
+++ b/hooks/useSignalPrice.ts
@@ -1,68 +1,99 @@
-import { useEffect, useRef, useState } from "react";
-import { traceWorker } from "@/src/tracing/worker-tracing.service";
-
-export interface SignalPrice {
-  executionPrice: number;
-  roi: number;
-  confidence: number;
-  updatedAt: Date;
-}
-
-type FlashColor = "up" | "down" | null;
-
-// Mock polling — replace with real WebSocket/API call
-function mockFetchPrice(current: SignalPrice): SignalPrice {
-  const delta = (Math.random() - 0.48) * 0.002;
-  const newPrice = parseFloat((current.executionPrice + delta).toFixed(4));
-  const roiDelta = (Math.random() - 0.48) * 0.5;
-  const newRoi = parseFloat((current.roi + roiDelta).toFixed(2));
-  const confDelta = Math.floor((Math.random() - 0.5) * 3);
-  const newConf = Math.min(100, Math.max(0, current.confidence + confDelta));
-  return { executionPrice: newPrice, roi: newRoi, confidence: newConf, updatedAt: new Date() };
-}
-
-export function useSignalPrice(intervalMs = 3000) {
-  const [price, setPrice] = useState<SignalPrice>({
-    executionPrice: 0.4821,
-    roi: 12.4,
-    confidence: 78,
-    updatedAt: new Date(),
-  });
-  const [flash, setFlash] = useState<FlashColor>(null);
-  const [relativeTime, setRelativeTime] = useState("just now");
-  const prevRef = useRef(price);
-
-  // Price polling
-  useEffect(() => {
-    const id = setInterval(() => {
-      traceWorker("worker:signalPrice:poll", async () => {
-        setPrice((prev) => {
-          const next = mockFetchPrice(prev);
-          const dir = next.executionPrice > prev.executionPrice ? "up" : next.executionPrice < prev.executionPrice ? "down" : null;
-          if (dir) {
-            setFlash(dir);
-            setTimeout(() => setFlash(null), 900);
-          }
-          prevRef.current = next;
-          return next;
-        });
-      }).catch(console.error);
-    }, intervalMs);
-    return () => clearInterval(id);
-  }, [intervalMs]);
-
-  // Relative timestamp — refreshes every 60s
-  useEffect(() => {
-    const fmt = () => {
-      const secs = Math.floor((Date.now() - price.updatedAt.getTime()) / 1000);
-      if (secs < 5) return "just now";
-      if (secs < 60) return `updated ${secs}s ago`;
-      return `updated ${Math.floor(secs / 60)}m ago`;
-    };
-    setRelativeTime(fmt());
-    const id = setInterval(() => setRelativeTime(fmt()), 60_000);
-    return () => clearInterval(id);
-  }, [price.updatedAt]);
-
-  return { price, flash, relativeTime };
+import { useEffect, useRef, useState } from "react";  
+import { traceWorker } from "@/src/tracing/worker-tracing.service";  
+  
+export interface SignalPrice {  
+  executionPrice: number;  
+  roi: number;  
+  confidence: number;  
+  updatedAt: Date;  
+}  
+  
+type FlashColor = "up" | "down" | null;  
+  
+// Mock polling — replace with real WebSocket/API call  
+function mockFetchPrice(current: SignalPrice): SignalPrice {  
+  const delta = (Math.random() - 0.48) * 0.002;  
+  const newPrice = parseFloat((current.executionPrice + delta).toFixed(4));  
+  const roiDelta = (Math.random() - 0.48) * 0.5;  
+  const newRoi = parseFloat((current.roi + roiDelta).toFixed(2));  
+  const confDelta = Math.floor((Math.random() - 0.5) * 3);  
+  const newConf = Math.min(100, Math.max(0, current.confidence + confDelta));  
+  return { executionPrice: newPrice, roi: newRoi, confidence: newConf, updatedAt: new Date() };  
+}  
+  
+export function useSignalPrice(intervalMs = 3000) {  
+  const [price, setPrice] = useState<SignalPrice>({  
+    executionPrice: 0.4821,  
+    roi: 12.4,  
+    confidence: 78,  
+    updatedAt: new Date(),  
+  });  
+  const [flash, setFlash] = useState<FlashColor>(null);  
+  const [relativeTime, setRelativeTime] = useState("just now");  
+  const [isStale, setIsStale] = useState(false);  
+  const prevRef = useRef(price);  
+  const failureCountRef = useRef(0);  
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);  
+  
+  // Calculate backoff delay using exponential backoff capped at 30s  
+  const getBackoffDelay = (failures: number): number => {  
+    return Math.min(intervalMs * Math.pow(2, failures), 30000);  
+  };  
+  
+  // Price polling with exponential backoff  
+  useEffect(() => {  
+    const poll = async () => {  
+      try {  
+        await traceWorker("worker:signalPrice:poll", async () => {  
+          setPrice((prev) => {  
+            const next = mockFetchPrice(prev);  
+            const dir = next.executionPrice > prev.executionPrice ? "up" : next.executionPrice < prev.executionPrice ? "down" : null;  
+            if (dir) {  
+              setFlash(dir);  
+              setTimeout(() => setFlash(null), 900);  
+            }  
+            prevRef.current = next;  
+            return next;  
+          });  
+        });  
+          
+        // Success: reset failure count and stale flag  
+        failureCountRef.current = 0;  
+        setIsStale(false);  
+      } catch (error) {  
+        // Failure: increment count and set stale flag  
+        failureCountRef.current += 1;  
+        setIsStale(true);  
+        console.error("Price poll failed:", error);  
+      }  
+        
+      // Schedule next poll with backoff  
+      const delay = getBackoffDelay(failureCountRef.current);  
+      timeoutRef.current = setTimeout(poll, delay);  
+    };  
+  
+    // Start polling  
+    timeoutRef.current = setTimeout(poll, intervalMs);  
+  
+    return () => {  
+      if (timeoutRef.current) {  
+        clearTimeout(timeoutRef.current);  
+      }  
+    };  
+  }, [intervalMs]);  
+  
+  // Relative timestamp — refreshes every 60s  
+  useEffect(() => {  
+    const fmt = () => {  
+      const secs = Math.floor((Date.now() - price.updatedAt.getTime()) / 1000);  
+      if (secs < 5) return "just now";  
+      if (secs < 60) return `updated ${secs}s ago`;  
+      return `updated ${Math.floor(secs / 60)}m ago`;  
+    };  
+    setRelativeTime(fmt());  
+    const id = setInterval(() => setRelativeTime(fmt()), 60_000);  
+    return () => clearInterval(id);  
+  }, [price.updatedAt]);  
+  
+  return { price, flash, relativeTime, isStale };  
 }


### PR DESCRIPTION
  
- Replace fixed setInterval with recursive setTimeout for dynamic polling  
- Track consecutive failures and apply exponential backoff (capped at 30s)  
- Expose isStale flag to indicate when price data may be outdated  
- Reset backoff to base interval on successful poll  
- Follow retry patterns from hooks/useSignals.ts and services/webhookService.ts  
  
Fixes issue where transient outages would cause silent polling failures   with stale UI display and no recovery mechanism.  

Closes # https://github.com/AgesEmpire/StellarSwipe-FrontEnd/issues/455