### PR TITLE
Add Open Graph and Twitter Card meta tags for social link previews

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,6 +21,27 @@ const inter = Inter({
 export const metadata: Metadata = {
   title: "StellarSwipe",
   description: "Stellar-powered swipe app",
+  openGraph: {
+    title: "StellarSwipe",
+    description: "Stellar-powered swipe app — discover top signal providers, trade tokens, and track performance on the Stellar network.",
+    url: "/",
+    siteName: "StellarSwipe",
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "StellarSwipe",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "StellarSwipe",
+    description: "Stellar-powered swipe app — discover top signal providers, trade tokens, and track performance on the Stellar network.",
+  },
 };
 
 export default function RootLayout({

--- a/app/leaderboard/layout.tsx
+++ b/app/leaderboard/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Leaderboard — StellarSwipe",
+  description:
+    "Browse top-performing signal providers on StellarSwipe. Compare win rates, scores, and recent performance across daily, weekly, monthly, and all-time rankings.",
+  openGraph: {
+    title: "Leaderboard — StellarSwipe",
+    description:
+      "Browse top-performing signal providers on StellarSwipe. Compare win rates, scores, and recent performance across daily, weekly, monthly, and all-time rankings.",
+    url: "/leaderboard",
+  },
+  twitter: {
+    title: "Leaderboard — StellarSwipe",
+    description:
+      "Browse top-performing signal providers on StellarSwipe. Compare win rates, scores, and recent performance across daily, weekly, monthly, and all-time rankings.",
+  },
+};
+
+export default function LeaderboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,88 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "StellarSwipe";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: "-50%",
+            right: "-20%",
+            width: "800px",
+            height: "800px",
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(59,130,246,0.15) 0%, transparent 70%)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: "-30%",
+            left: "-10%",
+            width: "600px",
+            height: "600px",
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(139,92,246,0.12) 0%, transparent 70%)",
+          }}
+        />
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "16px",
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontSize: "80px",
+              fontWeight: 800,
+              letterSpacing: "-0.03em",
+              color: "#f8fafc",
+              fontFamily: "system-ui, sans-serif",
+              textAlign: "center",
+            }}
+          >
+            StellarSwipe
+          </div>
+          <div
+            style={{
+              fontSize: "28px",
+              color: "#94a3b8",
+              fontWeight: 500,
+              fontFamily: "system-ui, sans-serif",
+              textAlign: "center",
+              maxWidth: "600px",
+            }}
+          >
+            Discover top signal providers, trade tokens, and track performance
+            on the Stellar network.
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/app/provider/[providerId]/layout.tsx
+++ b/app/provider/[providerId]/layout.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+type Props = {
+  params: { providerId: string };
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const providerId = params.providerId;
+
+  return {
+    title: `${providerId} — Provider Profile | StellarSwipe`,
+    description: `View the profile, performance stats, win rate, and recent signals for signal provider ${providerId} on StellarSwipe.`,
+    openGraph: {
+      title: `${providerId} — Provider Profile | StellarSwipe`,
+      description: `View the profile, performance stats, win rate, and recent signals for signal provider ${providerId} on StellarSwipe.`,
+      url: `/provider/${providerId}`,
+    },
+    twitter: {
+      title: `${providerId} — Provider Profile | StellarSwipe`,
+      description: `View the profile, performance stats, win rate, and recent signals for signal provider ${providerId} on StellarSwipe.`,
+    },
+  };
+}
+
+export default function ProviderLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}


### PR DESCRIPTION
Closes #434

## Changes

- **Root layout**: Added `openGraph` block (title, description, image, siteName, locale, type) and `twitter` block (`summary_large_image` card)
- **Leaderboard route**: Route-specific metadata with contextual title/description
- **Provider route**: Dynamic `generateMetadata` for route-specific titles/descriptions per provider
- **OG image**: Dynamic 1200×630 PNG generated via `next/og` (`ImageResponse`) with dark gradient background and StellarSwipe branding