### PR TITLE
feat: add Vitest CI step and fix comparison-tray test assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,13 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Test
+      - name: Test (Jest)
         run: npm test
 
-      - name: Test with Coverage
+      - name: Test (Vitest — comparison-tray suites)
+        run: npm run test:vitest
+
+      - name: Test with Coverage (Jest)
         run: npm run test:coverage
 
       - name: Upload Coverage Report

--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ In development (`NODE_ENV=development`) spans are logged to `console.debug`. Rep
 
 ### Running tests
 
-```bash
-npm test
-```
+Two test runners are configured:
+
+- **Jest** — runs the main test suites from store-level `__tests__` directories:
+  ```bash
+  npm test           # Jest (no coverage)
+  npm run test:coverage  # Jest with coverage
+  ```
+- **Vitest** — runs the comparison-tray suites at the project root `__tests__/`:
+  ```bash
+  npm run test:vitest
+  ```
+
+Both runners execute automatically in CI on every push/PR. The **Test (Jest)** step runs the main test suites, and the **Test (Vitest)** step runs the comparison-tray suites, ensuring that no regressions in the comparison-tray feature can merge undetected.

--- a/__tests__/ComparisonTray.test.tsx
+++ b/__tests__/ComparisonTray.test.tsx
@@ -66,12 +66,12 @@ describe("ComparisonTray – rendering", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders each signal's asset as a chip", () => {
+  it("renders each signal's ticker as a chip", () => {
     seedSignals(3);
     render(<ComparisonTray />);
-    expect(screen.getByText("Signal 1")).toBeInTheDocument();
-    expect(screen.getByText("Signal 2")).toBeInTheDocument();
-    expect(screen.getByText("Signal 3")).toBeInTheDocument();
+    expect(screen.getByText("S1")).toBeInTheDocument();
+    expect(screen.getByText("S2")).toBeInTheDocument();
+    expect(screen.getByText("S3")).toBeInTheDocument();
   });
 
   it("shows the 'Clear all' button when there are signals", () => {
@@ -126,7 +126,7 @@ describe("ComparisonTray – per-item remove", () => {
     seedSignals(3);
     render(<ComparisonTray />);
     const removeButtons = screen.getAllByRole("button", {
-      name: /remove signal/i,
+      name: /remove .* from comparison/i,
     });
     expect(removeButtons).toHaveLength(3);
   });
@@ -136,12 +136,12 @@ describe("ComparisonTray – per-item remove", () => {
     render(<ComparisonTray />);
 
     await userEvent.click(
-      screen.getByRole("button", { name: /remove signal 2/i })
+      screen.getByRole("button", { name: /remove S2 from comparison/i })
     );
 
-    expect(screen.queryByText("Signal 2")).not.toBeInTheDocument();
-    expect(screen.getByText("Signal 1")).toBeInTheDocument();
-    expect(screen.getByText("Signal 3")).toBeInTheDocument();
+    expect(screen.queryByText("S2")).not.toBeInTheDocument();
+    expect(screen.getByText("S1")).toBeInTheDocument();
+    expect(screen.getByText("S3")).toBeInTheDocument();
 
     const { signals } = useComparisonStore.getState();
     expect(signals.map((s) => s.id)).toEqual(["sig-1", "sig-3"]);
@@ -156,14 +156,14 @@ describe("ComparisonTray – clear all", () => {
     await userEvent.click(screen.getByRole("button", { name: /clear all/i }));
 
     expect(useComparisonStore.getState().signals).toHaveLength(0);
-    expect(screen.queryByText("Signal 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("S1")).not.toBeInTheDocument();
   });
 
   it("keeps per-item remove buttons working alongside clear all", () => {
     seedSignals(2);
     render(<ComparisonTray />);
     expect(
-      screen.getAllByRole("button", { name: /remove signal/i })
+      screen.getAllByRole("button", { name: /remove .* from comparison/i })
     ).toHaveLength(2);
     expect(
       screen.getByRole("button", { name: /clear all/i })

--- a/lib/arrayHelpers.ts
+++ b/lib/arrayHelpers.ts
@@ -1,0 +1,130 @@
+/**
+ * Array utility helpers for common comparison and transformation operations.
+ *
+ * These helpers are used across signal processing, comparison-tray operations,
+ * and general data manipulation to reduce repetitive inline logic.
+ */
+
+/**
+ * Partition an array into two arrays based on a predicate.
+ *
+ * @example
+ * const [valid, invalid] = partition(signals, s => s.confidence >= 50);
+ *
+ * @returns A tuple where the first element is items that passed the predicate
+ *          and the second element is items that failed.
+ */
+export function partition<T>(
+  items: T[],
+  predicate: (item: T, index: number) => boolean,
+): [T[], T[]] {
+  const pass: T[] = [];
+  const fail: T[] = [];
+  for (let i = 0; i < items.length; i++) {
+    if (predicate(items[i], i)) {
+      pass.push(items[i]);
+    } else {
+      fail.push(items[i]);
+    }
+  }
+  return [pass, fail];
+}
+
+/**
+ * Toggle an item in an array. If the item exists (via strict equality or
+ * a custom match function), it is removed. Otherwise it is appended.
+ *
+ * @example
+ * const updated = toggle(selectedIds, "sig-42");
+ */
+export function toggle<T>(
+  items: T[],
+  item: T,
+  matches?: (a: T, b: T) => boolean,
+): T[] {
+  const eq = matches ?? ((a: T, b: T) => a === b);
+  const index = items.findIndex((existing) => eq(existing, item));
+  if (index !== -1) {
+    return [...items.slice(0, index), ...items.slice(index + 1)];
+  }
+  return [...items, item];
+}
+
+/**
+ * Group an array of items by a key extracted from each item.
+ *
+ * @example
+ * const byAction = groupBy(signals, s => s.action);
+ * // { BUY: [sig1, sig3], SELL: [sig2] }
+ */
+export function groupBy<T, K extends string | number | symbol>(
+  items: T[],
+  keyFn: (item: T, index: number) => K,
+): Record<K, T[]> {
+  const result = {} as Record<K, T[]>;
+  for (let i = 0; i < items.length; i++) {
+    const key = keyFn(items[i], i);
+    if (!result[key]) {
+      result[key] = [];
+    }
+    result[key].push(items[i]);
+  }
+  return result;
+}
+
+/**
+ * Returns a new array with duplicate items removed. Uses strict equality
+ * by default, or an optional custom equality function.
+ *
+ * @example
+ * const unique = uniqBy(signals, (a, b) => a.id === b.id);
+ */
+export function uniqBy<T>(
+  items: T[],
+  equals: (a: T, b: T) => boolean = (a, b) => a === b,
+): T[] {
+  const result: T[] = [];
+  for (const item of items) {
+    if (!result.some((existing) => equals(existing, item))) {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+/**
+ * Move an item from one index to another within an array. Returns a new array.
+ * If the indices are out of bounds the original array is returned unchanged.
+ */
+export function moveItem<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  if (
+    fromIndex < 0 ||
+    fromIndex >= items.length ||
+    toIndex < 0 ||
+    toIndex >= items.length
+  ) {
+    return items;
+  }
+  const copy = [...items];
+  const [removed] = copy.splice(fromIndex, 1);
+  copy.splice(toIndex, 0, removed);
+  return copy;
+}
+
+/**
+ * Chunk an array into groups of the specified size. The final chunk may
+ * be smaller than `size`.
+ *
+ * @example
+ * chunk([1, 2, 3, 4, 5], 2) // [[1, 2], [3, 4], [5]]
+ */
+export function chunk<T>(items: T[], size: number): T[][] {
+  if (size <= 0) {
+    return [];
+  }
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    result.push(items.slice(i, i + size));
+  }
+  return result;
+}


### PR DESCRIPTION
This PR 
Closes #438


Implements somzilla.md issues:
- Add Vitest runner step to CI workflow so comparison-tray suites execute
- Fix pre-existing test assertion mismatches in ComparisonTray.test.tsx (component renders ticker not asset; aria-label uses 'Remove {ticker} from comparison')
- Update README testing section to document both Jest and Vitest in CI
- Add lib/arrayHelpers.ts with partition, toggle, groupBy, uniqBy, moveItem, chunk
- somzilla.md already in .gitignore